### PR TITLE
Added Secondary Constructors for Greater HttpClient Configurability

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -28,6 +28,12 @@ namespace GroqApiLibrary
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 
+        public GroqApiClient(string apiKey, HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+
         private async Task<string> ConvertImageToBase64(string imagePath)
         {
             if (!File.Exists(imagePath))

--- a/GroqLlmProvider.cs
+++ b/GroqLlmProvider.cs
@@ -25,6 +25,12 @@ namespace GroqApiLibrary
             _model = model;
         }
 
+        public GroqLlmProvider(string apiKey, string model, HttpClient httpClient)
+        {
+            _client = new GroqApiClient(apiKey, httpClient);
+            _model = model;
+        }
+
         public async Task<string> GenerateAsync(string prompt)
         {
             var request = new JsonObject


### PR DESCRIPTION
Added secondary constructor to GroqApiClient and GroqLlmProvider in order to pass in clients with existing policies, and prevent issues resulting from service life times.

Really appreciate the package by the way : )