### PR TITLE
v2.1.0: Groq API catch-up, usage analytics, optional prompt compression

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -19,13 +20,18 @@ namespace GroqApiLibrary
         private const string TranslationsEndpoint = "/audio/translations";
         private const string SpeechEndpoint = "/audio/speech";
 
-        // Updated vision models to include Llama 4 multimodal models
+        // Vision-capable models. Verified against console.groq.com/docs/models &amp; /deprecations (2026-07-12).
+        // qwen/qwen3.6-27b is the current recommended vision model. The Llama 4 / Llama 3.2 vision
+        // models are deprecated (Maverick decommissioned 2026-03-09, Scout shuts down 2026-07-17,
+        // Llama 3.2 vision long gone) but are retained here so existing callers still pass validation
+        // during the transition. Note: openai/gpt-oss-120b is text-only and is intentionally NOT listed.
         private static readonly HashSet<string> VisionModels = new(StringComparer.OrdinalIgnoreCase)
         {
-            "llama-3.2-90b-vision-preview",
-            "llama-3.2-11b-vision-preview",
+            "qwen/qwen3.6-27b",
             "meta-llama/llama-4-scout-17b-16e-instruct",
-            "meta-llama/llama-4-maverick-17b-128e-instruct"
+            "meta-llama/llama-4-maverick-17b-128e-instruct",
+            "llama-3.2-90b-vision-preview",
+            "llama-3.2-11b-vision-preview"
         };
 
         private const int MAX_IMAGE_SIZE_MB = 20;
@@ -78,6 +84,18 @@ namespace GroqApiLibrary
             }
 
             return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// Creates a chat completion from messages plus optional strongly-typed request parameters
+        /// (see <see cref="GroqChatOptions"/>). Read token usage/analytics from the response with
+        /// <see cref="GroqUsage.FromResponse"/>.
+        /// </summary>
+        public Task<JsonObject?> CreateChatCompletionAsync(JsonArray messages, string model, GroqChatOptions? options = null)
+        {
+            var request = new JsonObject { ["model"] = model, ["messages"] = messages };
+            options?.ApplyTo(request);
+            return CreateChatCompletionAsync(request);
         }
 
         public async IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request)
@@ -209,14 +227,23 @@ namespace GroqApiLibrary
 
         /// <summary>
         /// Creates a chat completion using Compound systems (groq/compound or groq/compound-mini)
-        /// with built-in web search and code execution capabilities.
+        /// with built-in server-side tools (web search, code execution, visit website, Wolfram Alpha).
+        /// The response includes an <c>executed_tools</c> array (which tools ran) and a
+        /// <c>usage_breakdown</c> object (per-underlying-model tokens); use
+        /// <see cref="GetExecutedTools"/> to read the former.
         /// </summary>
+        /// <param name="enabledTools">
+        /// Optional allow-list of built-in tools to enable (e.g. "web_search", "code_interpreter",
+        /// "visit_website", "wolfram_alpha"), sent as compound_custom.tools.enabled_tools. When null,
+        /// the system default set is used.
+        /// </param>
         public async Task<JsonObject?> CreateCompoundCompletionAsync(
             JsonArray messages,
             bool useMini = false,
             SearchSettings? searchSettings = null,
             float? temperature = null,
-            int? maxCompletionTokens = null)
+            int? maxCompletionTokens = null,
+            string[]? enabledTools = null)
         {
             var request = new JsonObject
             {
@@ -234,6 +261,16 @@ namespace GroqApiLibrary
                 request["search_settings"] = settings;
             }
 
+            if (enabledTools is { Length: > 0 })
+            {
+                var tools = new JsonArray();
+                foreach (var t in enabledTools) tools.Add(t);
+                request["compound_custom"] = new JsonObject
+                {
+                    ["tools"] = new JsonObject { ["enabled_tools"] = tools }
+                };
+            }
+
             if (temperature.HasValue)
                 request["temperature"] = temperature.Value;
 
@@ -242,6 +279,13 @@ namespace GroqApiLibrary
 
             return await CreateChatCompletionAsync(request);
         }
+
+        /// <summary>
+        /// Returns the <c>executed_tools</c> array from a Compound response (the built-in tools the
+        /// system ran while producing the answer), or null if none is present.
+        /// </summary>
+        public static JsonArray? GetExecutedTools(JsonObject? response)
+            => response?["choices"]?[0]?["message"]?["executed_tools"] as JsonArray;
 
         #endregion
 
@@ -290,6 +334,57 @@ namespace GroqApiLibrary
             return await response.Content.ReadFromJsonAsync<JsonObject>();
         }
 
+        /// <summary>
+        /// Transcribes audio from a publicly accessible URL, avoiding an upload. Alternative to the
+        /// multipart <see cref="CreateTranscriptionAsync"/>.
+        /// </summary>
+        public async Task<JsonObject?> CreateTranscriptionFromUrlAsync(string url, string model,
+            string? prompt = null, string responseFormat = "json", string? language = null, float? temperature = null)
+        {
+            using var content = new MultipartFormDataContent();
+            content.Add(new StringContent(url), "url");
+            content.Add(new StringContent(model), "model");
+
+            if (!string.IsNullOrEmpty(prompt))
+                content.Add(new StringContent(prompt), "prompt");
+
+            content.Add(new StringContent(responseFormat), "response_format");
+
+            if (!string.IsNullOrEmpty(language))
+                content.Add(new StringContent(language), "language");
+
+            if (temperature.HasValue)
+                content.Add(new StringContent(temperature.Value.ToString(CultureInfo.InvariantCulture)), "temperature");
+
+            var response = await _httpClient.PostAsync(BaseUrl + TranscriptionsEndpoint, content);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// Translates audio from a publicly accessible URL to English, avoiding an upload. Alternative
+        /// to the multipart <see cref="CreateTranslationAsync"/>.
+        /// </summary>
+        public async Task<JsonObject?> CreateTranslationFromUrlAsync(string url, string model,
+            string? prompt = null, string responseFormat = "json", float? temperature = null)
+        {
+            using var content = new MultipartFormDataContent();
+            content.Add(new StringContent(url), "url");
+            content.Add(new StringContent(model), "model");
+
+            if (!string.IsNullOrEmpty(prompt))
+                content.Add(new StringContent(prompt), "prompt");
+
+            content.Add(new StringContent(responseFormat), "response_format");
+
+            if (temperature.HasValue)
+                content.Add(new StringContent(temperature.Value.ToString(CultureInfo.InvariantCulture)), "temperature");
+
+            var response = await _httpClient.PostAsync(BaseUrl + TranslationsEndpoint, content);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
         #endregion
 
         #region Text-to-Speech
@@ -297,11 +392,11 @@ namespace GroqApiLibrary
         /// <summary>
         /// Converts text to speech audio using Orpheus TTS models.
         /// </summary>
-        /// <param name="text">The text to convert to speech. Supports vocal directions in brackets like [cheerful], [sad], etc.</param>
-        /// <param name="voice">Voice to use. For English: tara, leah, jess, leo, dan, mia, zac, zoe. For Arabic: abdullah, amira.</param>
+        /// <param name="text">The text to convert to speech (max 200 characters). English supports vocal directions in brackets like [cheerful], [whisper], [dramatic].</param>
+        /// <param name="voice">Voice to use. English (orpheus-v1-english): autumn, diana, hannah, austin, daniel, troy. Arabic (orpheus-arabic-saudi): abdullah, fahad, sultan, lulwa, noura, aisha. See <see cref="OrpheusVoices"/>.</param>
         /// <param name="model">TTS model: canopylabs/orpheus-v1-english or canopylabs/orpheus-arabic-saudi</param>
-        /// <param name="responseFormat">Audio format: wav (default), mp3, opus, flac</param>
-        /// <returns>Audio bytes</returns>
+        /// <param name="responseFormat">Audio format. Orpheus only supports "wav"; other values are not accepted by the API.</param>
+        /// <returns>Audio bytes (WAV)</returns>
         public async Task<byte[]> CreateSpeechAsync(
             string text,
             string voice,
@@ -384,7 +479,7 @@ namespace GroqApiLibrary
         public async Task<JsonObject?> CreateVisionCompletionWithImageUrlAsync(
             string imageUrl,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             float? temperature = null)
         {
             ValidateImageUrl(imageUrl);
@@ -428,7 +523,7 @@ namespace GroqApiLibrary
         public async Task<JsonObject?> CreateVisionCompletionWithBase64ImageAsync(
             string imagePath,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             float? temperature = null)
         {
             var base64Image = await ConvertImageToBase64(imagePath);
@@ -475,7 +570,7 @@ namespace GroqApiLibrary
             string imageUrl,
             string prompt,
             List<Tool> tools,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             bool parallelToolCalls = true)
         {
             ValidateImageUrl(imageUrl);
@@ -526,7 +621,7 @@ namespace GroqApiLibrary
         public async Task<JsonObject?> CreateVisionCompletionWithJsonModeAsync(
             string imageUrl,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct")
+            string model = "qwen/qwen3.6-27b")
         {
             ValidateImageUrl(imageUrl);
 
@@ -571,7 +666,7 @@ namespace GroqApiLibrary
             JsonObject jsonSchema,
             string schemaName = "response",
             bool strict = false,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct")
+            string model = "qwen/qwen3.6-27b")
         {
             ValidateImageUrl(imageUrl);
 
@@ -804,69 +899,85 @@ namespace GroqApiLibrary
     }
 
     /// <summary>
-    /// Known model identifiers for convenience
+    /// Known model identifiers for convenience.
+    /// Verified against console.groq.com/docs/models and /deprecations as of 2026-07-12.
+    /// Members marked [Obsolete] are deprecated or already decommissioned on GroqCloud;
+    /// the message names the current replacement.
     /// </summary>
     public static class GroqModels
     {
-        // Production chat models
-        public const string Llama31_8B = "llama-3.1-8b-instant";
-        public const string Llama33_70B = "llama-3.3-70b-versatile";
-        
-        // GPT-OSS models (support structured outputs with strict mode)
-        public const string GptOss20B = "openai/gpt-oss-20b";
+        // ----- Recommended current models -----
+
+        // GPT-OSS: open-weight, reasoning + built-in tools, structured outputs with strict mode.
+        // GptOss120B is the recommended default chat model. NOTE: text-only (not vision-capable).
         public const string GptOss120B = "openai/gpt-oss-120b";
+        public const string GptOss20B = "openai/gpt-oss-20b";
         public const string GptOssSafeguard20B = "openai/gpt-oss-safeguard-20b";
-        
-        // Llama 4 multimodal models
-        public const string Llama4Scout = "meta-llama/llama-4-scout-17b-16e-instruct";
-        public const string Llama4Maverick = "meta-llama/llama-4-maverick-17b-128e-instruct";
-        
-        // Qwen (supports reasoning)
-        public const string Qwen3_32B = "qwen/qwen3-32b";
-        
-        // Other models
-        public const string KimiK2 = "moonshotai/kimi-k2-instruct-0905";
-        
-        // Compound systems
+
+        // Qwen 3.6 27B: current recommended reasoning + vision-capable model (131K context).
+        public const string Qwen36_27B = "qwen/qwen3.6-27b";
+
+        // Compound agentic systems (used via the chat endpoint by setting the model).
         public const string Compound = "groq/compound";
         public const string CompoundMini = "groq/compound-mini";
-        
-        // Guard models
+
+        // Guard / safety models.
         public const string LlamaGuard4 = "meta-llama/llama-guard-4-12b";
         public const string PromptGuard22M = "meta-llama/llama-prompt-guard-2-22m";
         public const string PromptGuard86M = "meta-llama/llama-prompt-guard-2-86m";
-        
-        // Audio models
+
+        // Audio (speech-to-text).
         public const string WhisperLargeV3 = "whisper-large-v3";
         public const string WhisperLargeV3Turbo = "whisper-large-v3-turbo";
-        
-        // TTS models
+
+        // Text-to-speech (Orpheus).
         public const string OrpheusEnglish = "canopylabs/orpheus-v1-english";
         public const string OrpheusArabic = "canopylabs/orpheus-arabic-saudi";
-        
-        // Legacy vision models (still supported)
+
+        // ----- Deprecated: still served for now, but scheduled for shutdown -----
+
+        [Obsolete("Deprecated on GroqCloud; shuts down 2026-08-16. Use GptOss20B.")]
+        public const string Llama31_8B = "llama-3.1-8b-instant";
+        [Obsolete("Deprecated on GroqCloud; shuts down 2026-08-16. Use GptOss120B or Qwen36_27B.")]
+        public const string Llama33_70B = "llama-3.3-70b-versatile";
+        [Obsolete("Deprecated on GroqCloud; shuts down 2026-07-17. Use Qwen36_27B (vision) or GptOss120B.")]
+        public const string Llama4Scout = "meta-llama/llama-4-scout-17b-16e-instruct";
+        [Obsolete("Deprecated on GroqCloud; shuts down 2026-07-17. Use GptOss120B.")]
+        public const string Qwen3_32B = "qwen/qwen3-32b";
+
+        // ----- Decommissioned: no longer served by GroqCloud (calls will fail) -----
+
+        [Obsolete("DECOMMISSIONED 2026-04-15 - no longer served. Use GptOss120B.")]
+        public const string KimiK2 = "moonshotai/kimi-k2-instruct-0905";
+        [Obsolete("DECOMMISSIONED 2026-03-09 - no longer served. Use GptOss120B.")]
+        public const string Llama4Maverick = "meta-llama/llama-4-maverick-17b-128e-instruct";
+        [Obsolete("DECOMMISSIONED - llama-3.2 vision no longer served. Use Qwen36_27B for vision.")]
         public const string Llama32_90BVision = "llama-3.2-90b-vision-preview";
+        [Obsolete("DECOMMISSIONED - llama-3.2 vision no longer served. Use Qwen36_27B for vision.")]
         public const string Llama32_11BVision = "llama-3.2-11b-vision-preview";
     }
 
     /// <summary>
-    /// Known TTS voices for Orpheus models
+    /// Known TTS voices for Orpheus models.
+    /// Verified against console.groq.com/docs/text-to-speech/orpheus as of 2026-07-12.
     /// </summary>
     public static class OrpheusVoices
     {
         // English voices (canopylabs/orpheus-v1-english)
-        public const string Tara = "tara";
-        public const string Leah = "leah";
-        public const string Jess = "jess";
-        public const string Leo = "leo";
-        public const string Dan = "dan";
-        public const string Mia = "mia";
-        public const string Zac = "zac";
-        public const string Zoe = "zoe";
-        
+        public const string Autumn = "autumn";
+        public const string Diana = "diana";
+        public const string Hannah = "hannah";
+        public const string Austin = "austin";
+        public const string Daniel = "daniel";
+        public const string Troy = "troy";
+
         // Arabic voices (canopylabs/orpheus-arabic-saudi)
         public const string Abdullah = "abdullah";
-        public const string Amira = "amira";
+        public const string Fahad = "fahad";
+        public const string Sultan = "sultan";
+        public const string Lulwa = "lulwa";
+        public const string Noura = "noura";
+        public const string Aisha = "aisha";
     }
 
     /// <summary>

--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -14,9 +14,9 @@
 		<PackageIcon>g_icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Groq, API, Windows, .NET, Core, AI, LLM, TTS, Whisper, Vision, Tool-Calling, Structured-Outputs</PackageTags>
-		<AssemblyVersion>2.0.0.0</AssemblyVersion>
-		<FileVersion>2.0.0.0</FileVersion>
-		<Version>2.0.0</Version>
+		<AssemblyVersion>2.1.0.0</AssemblyVersion>
+		<FileVersion>2.1.0.0</FileVersion>
+		<Version>2.1.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 

--- a/GroqChatOptions.cs
+++ b/GroqChatOptions.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// Optional chat-completion request parameters. Set only what you need; null properties are omitted
+    /// from the request. Apply to an existing request with <see cref="ApplyTo"/>, or build a fresh
+    /// request with <see cref="ToRequest"/>.
+    /// Verified against console.groq.com/docs/api-reference as of 2026-07-12.
+    /// </summary>
+    /// <remarks>
+    /// frequency_penalty, presence_penalty, logprobs and n are intentionally omitted: Groq currently
+    /// accepts but ignores them (n only supports 1).
+    /// </remarks>
+    public class GroqChatOptions
+    {
+        /// <summary>Sampling temperature (0-2).</summary>
+        public double? Temperature { get; set; }
+
+        /// <summary>Nucleus sampling probability mass (0-1).</summary>
+        public double? TopP { get; set; }
+
+        /// <summary>Maximum tokens to generate. Preferred over the deprecated max_tokens.</summary>
+        public int? MaxCompletionTokens { get; set; }
+
+        /// <summary>Seed for best-effort deterministic sampling.</summary>
+        public int? Seed { get; set; }
+
+        /// <summary>Up to 4 stop sequences.</summary>
+        public string[]? Stop { get; set; }
+
+        /// <summary>Allow the model to request multiple tool calls in parallel (default true on Groq).</summary>
+        public bool? ParallelToolCalls { get; set; }
+
+        /// <summary>
+        /// Tool selection: a string ("none" | "auto" | "required") or a specific tool object.
+        /// The value is deep-copied when applied, so a node with an existing parent is safe to pass.
+        /// </summary>
+        public JsonNode? ToolChoice { get; set; }
+
+        /// <summary>Service tier: see <see cref="ServiceTiers"/> (auto/on_demand/flex/performance).</summary>
+        public string? ServiceTier { get; set; }
+
+        /// <summary>Reasoning effort: see <see cref="GroqApiLibrary.ReasoningEffort"/>. Model-specific valid values.</summary>
+        public string? ReasoningEffort { get; set; }
+
+        /// <summary>Reasoning format: see <see cref="GroqApiLibrary.ReasoningFormat"/>. Mutually exclusive with <see cref="IncludeReasoning"/>.</summary>
+        public string? ReasoningFormat { get; set; }
+
+        /// <summary>gpt-oss only: emit reasoning as a separate field. Mutually exclusive with <see cref="ReasoningFormat"/>.</summary>
+        public bool? IncludeReasoning { get; set; }
+
+        /// <summary>Opaque end-user identifier.</summary>
+        public string? User { get; set; }
+
+        /// <summary>When streaming, request usage stats in the final chunk (stream_options.include_usage).</summary>
+        public bool? StreamIncludeUsage { get; set; }
+
+        /// <summary>Merges the set options into <paramref name="request"/> and returns it.</summary>
+        public JsonObject ApplyTo(JsonObject request)
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+
+            if (Temperature.HasValue) request["temperature"] = Temperature.Value;
+            if (TopP.HasValue) request["top_p"] = TopP.Value;
+            if (MaxCompletionTokens.HasValue) request["max_completion_tokens"] = MaxCompletionTokens.Value;
+            if (Seed.HasValue) request["seed"] = Seed.Value;
+
+            if (Stop is { Length: > 0 })
+            {
+                var arr = new JsonArray();
+                foreach (var s in Stop) arr.Add(s);
+                request["stop"] = arr;
+            }
+
+            if (ParallelToolCalls.HasValue) request["parallel_tool_calls"] = ParallelToolCalls.Value;
+            if (ToolChoice is not null) request["tool_choice"] = Clone(ToolChoice);
+            if (!string.IsNullOrEmpty(ServiceTier)) request["service_tier"] = ServiceTier;
+            if (!string.IsNullOrEmpty(ReasoningEffort)) request["reasoning_effort"] = ReasoningEffort;
+            if (!string.IsNullOrEmpty(ReasoningFormat)) request["reasoning_format"] = ReasoningFormat;
+            if (IncludeReasoning.HasValue) request["include_reasoning"] = IncludeReasoning.Value;
+            if (!string.IsNullOrEmpty(User)) request["user"] = User;
+
+            if (StreamIncludeUsage.HasValue)
+                request["stream_options"] = new JsonObject { ["include_usage"] = StreamIncludeUsage.Value };
+
+            return request;
+        }
+
+        /// <summary>Builds a new request object from <paramref name="model"/>, <paramref name="messages"/> and these options.</summary>
+        public JsonObject ToRequest(string model, JsonArray messages)
+        {
+            var request = new JsonObject { ["model"] = model, ["messages"] = messages };
+            return ApplyTo(request);
+        }
+
+        // JsonNode.DeepClone() is only available on net9+; this library targets net8.0, so clone via round-trip.
+        private static JsonNode Clone(JsonNode node) => JsonNode.Parse(node.ToJsonString())!;
+    }
+}

--- a/GroqLlmProvider.cs
+++ b/GroqLlmProvider.cs
@@ -18,21 +18,28 @@ namespace GroqApiLibrary
     {
         private readonly GroqApiClient _client;
         private readonly string _model;
+        private readonly IPromptCompressor? _compressor;
 
-        public GroqLlmProvider(string apiKey, string model)
+        public GroqLlmProvider(string apiKey, string model, IPromptCompressor? compressor = null)
         {
             _client = new GroqApiClient(apiKey);
             _model = model;
+            _compressor = compressor;
         }
 
-        public GroqLlmProvider(string apiKey, string model, HttpClient httpClient)
+        public GroqLlmProvider(string apiKey, string model, HttpClient httpClient, IPromptCompressor? compressor = null)
         {
             _client = new GroqApiClient(apiKey, httpClient);
             _model = model;
+            _compressor = compressor;
         }
 
         public async Task<string> GenerateAsync(string prompt)
         {
+            // Opt-in prompt compression: when no compressor was supplied, the prompt is sent unchanged.
+            if (_compressor != null)
+                prompt = await _compressor.CompressAsync(prompt);
+
             var request = new JsonObject
             {
                 ["model"] = _model,

--- a/GroqUsage.cs
+++ b/GroqUsage.cs
@@ -1,0 +1,78 @@
+using System.Text.Json.Nodes;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// Token usage, prompt-cache hits and timing for a chat completion, parsed from a response's
+    /// <c>usage</c> object (and top-level <c>x_groq.id</c>).
+    /// Verified against console.groq.com/docs as of 2026-07-12.
+    /// </summary>
+    public class GroqUsage
+    {
+        /// <summary>Input (prompt) tokens billed.</summary>
+        public int PromptTokens { get; set; }
+
+        /// <summary>Output (completion) tokens billed.</summary>
+        public int CompletionTokens { get; set; }
+
+        /// <summary>Total tokens billed.</summary>
+        public int TotalTokens { get; set; }
+
+        /// <summary>
+        /// Cached prompt tokens (from usage.prompt_tokens_details.cached_tokens). Prompt caching is
+        /// automatic on supported models and bills cached input at a discount; 0 when there is no hit.
+        /// </summary>
+        public int CachedTokens { get; set; }
+
+        /// <summary>Seconds the request spent queued.</summary>
+        public double? QueueTime { get; set; }
+
+        /// <summary>Seconds spent processing the prompt.</summary>
+        public double? PromptTime { get; set; }
+
+        /// <summary>Seconds spent generating the completion.</summary>
+        public double? CompletionTime { get; set; }
+
+        /// <summary>Total server-side seconds.</summary>
+        public double? TotalTime { get; set; }
+
+        /// <summary>Groq request id (response x_groq.id), useful for tracing/support.</summary>
+        public string? RequestId { get; set; }
+
+        /// <summary>Fraction of prompt tokens served from cache (0-1). 0 when there is no prompt cache hit.</summary>
+        public double CacheHitRatio => PromptTokens > 0 ? (double)CachedTokens / PromptTokens : 0d;
+
+        /// <summary>
+        /// Extracts usage/analytics from a chat-completion response, or returns null if the response
+        /// carries no <c>usage</c> object.
+        /// </summary>
+        public static GroqUsage? FromResponse(JsonObject? response)
+        {
+            if (response is null) return null;
+            if (response["usage"] is not JsonObject usage) return null;
+
+            var result = new GroqUsage
+            {
+                PromptTokens = GetInt(usage, "prompt_tokens"),
+                CompletionTokens = GetInt(usage, "completion_tokens"),
+                TotalTokens = GetInt(usage, "total_tokens"),
+                QueueTime = GetDouble(usage, "queue_time"),
+                PromptTime = GetDouble(usage, "prompt_time"),
+                CompletionTime = GetDouble(usage, "completion_time"),
+                TotalTime = GetDouble(usage, "total_time"),
+                RequestId = (response["x_groq"] as JsonObject)?["id"]?.GetValue<string>()
+            };
+
+            if (usage["prompt_tokens_details"] is JsonObject details)
+                result.CachedTokens = GetInt(details, "cached_tokens");
+
+            return result;
+        }
+
+        private static int GetInt(JsonObject o, string key)
+            => o[key] is JsonValue v && v.TryGetValue<int>(out var i) ? i : 0;
+
+        private static double? GetDouble(JsonObject o, string key)
+            => o[key] is JsonValue v && v.TryGetValue<double>(out var d) ? d : null;
+    }
+}

--- a/IGroqApiClient.cs
+++ b/IGroqApiClient.cs
@@ -12,6 +12,12 @@ namespace GroqApiLibrary
         Task<JsonObject?> CreateChatCompletionAsync(JsonObject request);
 
         /// <summary>
+        /// Creates a chat completion from messages plus optional strongly-typed request parameters
+        /// (see <see cref="GroqChatOptions"/>). Read usage/analytics with <see cref="GroqUsage.FromResponse"/>.
+        /// </summary>
+        Task<JsonObject?> CreateChatCompletionAsync(JsonArray messages, string model, GroqChatOptions? options = null);
+
+        /// <summary>
         /// Creates a streaming chat completion.
         /// </summary>
         IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request);
@@ -59,7 +65,8 @@ namespace GroqApiLibrary
             bool useMini = false,
             SearchSettings? searchSettings = null,
             float? temperature = null,
-            int? maxCompletionTokens = null);
+            int? maxCompletionTokens = null,
+            string[]? enabledTools = null);
 
         #endregion
 
@@ -81,11 +88,32 @@ namespace GroqApiLibrary
         /// Translates audio to English text using Whisper models.
         /// </summary>
         Task<JsonObject?> CreateTranslationAsync(
-            Stream audioFile, 
-            string fileName, 
+            Stream audioFile,
+            string fileName,
             string model,
-            string? prompt = null, 
-            string responseFormat = "json", 
+            string? prompt = null,
+            string responseFormat = "json",
+            float? temperature = null);
+
+        /// <summary>
+        /// Transcribes audio from a publicly accessible URL (no upload) using Whisper models.
+        /// </summary>
+        Task<JsonObject?> CreateTranscriptionFromUrlAsync(
+            string url,
+            string model,
+            string? prompt = null,
+            string responseFormat = "json",
+            string? language = null,
+            float? temperature = null);
+
+        /// <summary>
+        /// Translates audio from a publicly accessible URL (no upload) to English using Whisper models.
+        /// </summary>
+        Task<JsonObject?> CreateTranslationFromUrlAsync(
+            string url,
+            string model,
+            string? prompt = null,
+            string responseFormat = "json",
             float? temperature = null);
 
         /// <summary>
@@ -131,7 +159,7 @@ namespace GroqApiLibrary
         Task<JsonObject?> CreateVisionCompletionWithImageUrlAsync(
             string imageUrl,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             float? temperature = null);
 
         /// <summary>
@@ -140,7 +168,7 @@ namespace GroqApiLibrary
         Task<JsonObject?> CreateVisionCompletionWithBase64ImageAsync(
             string imagePath,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             float? temperature = null);
 
         /// <summary>
@@ -150,7 +178,7 @@ namespace GroqApiLibrary
             string imageUrl,
             string prompt,
             List<Tool> tools,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct",
+            string model = "qwen/qwen3.6-27b",
             bool parallelToolCalls = true);
 
         /// <summary>
@@ -159,7 +187,7 @@ namespace GroqApiLibrary
         Task<JsonObject?> CreateVisionCompletionWithJsonModeAsync(
             string imageUrl,
             string prompt,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct");
+            string model = "qwen/qwen3.6-27b");
 
         /// <summary>
         /// Creates a vision completion with structured JSON output.
@@ -170,7 +198,7 @@ namespace GroqApiLibrary
             JsonObject jsonSchema,
             string schemaName = "response",
             bool strict = false,
-            string model = "meta-llama/llama-4-scout-17b-16e-instruct");
+            string model = "qwen/qwen3.6-27b");
 
         #endregion
 

--- a/PromptCompression.cs
+++ b/PromptCompression.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// Optional pre-send prompt transform. Implementations reduce a prompt's token footprint before
+    /// it is sent to the model ("greening"/cost reduction). This is <b>lossy token reduction</b>, not
+    /// a reversible compress/decompress — the model reads the transformed text directly, so weigh the
+    /// quality/cost trade-off per use case. Compression is <b>opt-in</b>: when no compressor is supplied,
+    /// prompts are sent unchanged.
+    /// </summary>
+    public interface IPromptCompressor
+    {
+        /// <summary>Returns a shorter form of <paramref name="prompt"/>. May return it unchanged.</summary>
+        Task<string> CompressAsync(string prompt);
+    }
+
+    /// <summary>
+    /// Deterministic, zero-cost, near-lossless compressor: collapses redundant whitespace and trims.
+    /// Makes no network calls, changes no wording, and is safe as a default. Savings are modest
+    /// (mostly on heavily-indented or padded prompts).
+    /// </summary>
+    public sealed class WhitespaceCompressor : IPromptCompressor
+    {
+        private static readonly Regex TrailingWhitespace = new(@"[ \t]+(\r?\n)", RegexOptions.Compiled);
+        private static readonly Regex InlineRuns = new(@"[ \t]{2,}", RegexOptions.Compiled);
+        private static readonly Regex BlankLineRuns = new(@"(\r?\n){3,}", RegexOptions.Compiled);
+
+        public Task<string> CompressAsync(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt)) return Task.FromResult(prompt);
+
+            var result = TrailingWhitespace.Replace(prompt, "$1"); // drop trailing spaces on each line
+            result = InlineRuns.Replace(result, " ");              // collapse runs of spaces/tabs
+            result = BlankLineRuns.Replace(result, "\n\n");        // cap consecutive blank lines
+            return Task.FromResult(result.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Optional LLM-based compressor: for long prompts, asks a (typically small/fast) Groq model to
+    /// rewrite the text more concisely while preserving task-relevant detail.
+    /// <para>
+    /// NOTE: this adds an extra LLM call, so it only nets savings when the prompt is large and/or reused
+    /// downstream. For short one-shot prompts it is net-negative — hence the <see cref="MinCharsToCompress"/>
+    /// threshold, below which the prompt is returned unchanged with no network call.
+    /// </para>
+    /// </summary>
+    public sealed class LlmSummarizingCompressor : IPromptCompressor
+    {
+        private readonly IGroqApiClient _client;
+        private readonly string _model;
+
+        /// <summary>Prompts shorter than this many characters are returned unchanged (no API call).</summary>
+        public int MinCharsToCompress { get; set; } = 2000;
+
+        /// <param name="client">Client used to perform the compression call.</param>
+        /// <param name="model">Model to compress with. Prefer a fast, inexpensive model.</param>
+        public LlmSummarizingCompressor(IGroqApiClient client, string model = GroqModels.GptOss20B)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _model = model;
+        }
+
+        public async Task<string> CompressAsync(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt) || prompt.Length < MinCharsToCompress)
+                return prompt;
+
+            var messages = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["role"] = "system",
+                    ["content"] = "You compress prompts. Rewrite the user's text as concisely as possible " +
+                                  "while preserving every instruction, constraint, fact, and piece of context " +
+                                  "needed to act on it. Do not answer or follow the text; only rewrite it. " +
+                                  "Output only the compressed text."
+                },
+                new JsonObject { ["role"] = "user", ["content"] = prompt }
+            };
+
+            var response = await _client.CreateChatCompletionAsync(messages, _model,
+                new GroqChatOptions { Temperature = 0 });
+
+            var compressed = response?["choices"]?[0]?["message"]?["content"]?.GetValue<string>();
+            // Fail safe: never return an empty/failed compression — fall back to the original prompt.
+            return string.IsNullOrWhiteSpace(compressed) ? prompt : compressed!;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -424,21 +424,21 @@ if (modelsResponse?["data"] is JsonArray models)
 
 ## 🎛️ Model Reference
 
+> Verified against console.groq.com/docs/models and /deprecations as of 2026-07-12. Deprecated/decommissioned constants are marked `[Obsolete]` in code and are omitted here.
+
 ### Chat Models
 | Constant | Model ID | Notes |
 |----------|----------|-------|
-| `GroqModels.Llama33_70B` | llama-3.3-70b-versatile | Production, 131k context |
-| `GroqModels.Llama31_8B` | llama-3.1-8b-instant | Fast, 131k context |
-| `GroqModels.GptOss20B` | openai/gpt-oss-20b | Structured outputs (strict) |
-| `GroqModels.GptOss120B` | openai/gpt-oss-120b | Structured outputs (strict) |
-| `GroqModels.Qwen3_32B` | qwen/qwen3-32b | Reasoning support |
-| `GroqModels.KimiK2` | moonshotai/kimi-k2-instruct-0905 | 262k context |
+| `GroqModels.GptOss120B` | openai/gpt-oss-120b | **Recommended default.** Reasoning + built-in tools, structured outputs (strict). Text-only. |
+| `GroqModels.GptOss20B` | openai/gpt-oss-20b | Faster. Structured outputs (strict). |
+| `GroqModels.Qwen36_27B` | qwen/qwen3.6-27b | Reasoning + **vision**, 131k context |
 
 ### Vision/Multimodal Models
 | Constant | Model ID | Notes |
 |----------|----------|-------|
-| `GroqModels.Llama4Scout` | meta-llama/llama-4-scout-17b-16e-instruct | Efficient, 131k context |
-| `GroqModels.Llama4Maverick` | meta-llama/llama-4-maverick-17b-128e-instruct | High capacity |
+| `GroqModels.Qwen36_27B` | qwen/qwen3.6-27b | **Recommended vision model.** (`gpt-oss-120b` is text-only.) |
+
+> The former Llama 4 (`Llama4Scout`, `Llama4Maverick`) and Llama 3.2 vision constants are deprecated/decommissioned on GroqCloud. They remain in code as `[Obsolete]` for source compatibility but should not be used.
 
 ### Compound Systems
 | Constant | Model ID | Notes |
@@ -463,15 +463,87 @@ if (modelsResponse?["data"] is JsonArray models)
 
 ## 🗣️ TTS Voice Reference
 
-### English Voices (OrpheusVoices)
-- `Tara`, `Leah`, `Jess`, `Mia`, `Zoe` (female)
-- `Leo`, `Dan`, `Zac` (male)
+### English Voices (OrpheusVoices, `canopylabs/orpheus-v1-english`)
+- `Autumn`, `Diana`, `Hannah`, `Austin`, `Daniel`, `Troy`
 
-### Arabic Voices
-- `Abdullah` (male), `Amira` (female)
+### Arabic Voices (`canopylabs/orpheus-arabic-saudi`)
+- `Abdullah`, `Fahad`, `Sultan`, `Lulwa`, `Noura`, `Aisha`
 
-### Vocal Directions
-Add emotion/style in brackets: `[cheerful]`, `[sad]`, `[serious]`, `[excited]`, `[whisper]`
+### Notes
+- Output format is **WAV only**; input is capped at **200 characters**.
+- English supports vocal directions in brackets: `[cheerful]`, `[whisper]`, `[dramatic]`, `[excited]`
+
+## 🧰 Request Options & Usage Analytics (v2.1)
+
+Pass strongly-typed parameters with `GroqChatOptions` instead of hand-building every field, and read
+token usage / prompt-cache hits / timing from any response with `GroqUsage`:
+
+```csharp
+var messages = new JsonArray
+{
+    new JsonObject { ["role"] = "user", ["content"] = "Explain LPUs in one sentence." }
+};
+
+var response = await groqApi.CreateChatCompletionAsync(messages, GroqModels.GptOss120B, new GroqChatOptions
+{
+    Temperature = 0.2,
+    MaxCompletionTokens = 256,
+    ServiceTier = ServiceTiers.Flex,
+    ReasoningEffort = ReasoningEffort.Low,
+    Seed = 42
+});
+
+var usage = GroqUsage.FromResponse(response);
+if (usage != null)
+    Console.WriteLine($"tokens: {usage.TotalTokens} (cached {usage.CachedTokens}, " +
+                      $"{usage.CacheHitRatio:P0}), {usage.TotalTime}s, id={usage.RequestId}");
+```
+
+Prompt caching is automatic on supported models (e.g. `gpt-oss-120b`); `usage.CachedTokens` shows how
+many input tokens were served from cache (billed at a discount).
+
+## 🎙️ Transcription from a URL (v2.1)
+
+```csharp
+var result = await groqApi.CreateTranscriptionFromUrlAsync(
+    "https://example.com/audio.mp3", GroqModels.WhisperLargeV3Turbo);
+```
+
+## 🧠 Compound: enable specific tools & inspect what ran (v2.1)
+
+```csharp
+var response = await groqApi.CreateCompoundCompletionAsync(
+    messages,
+    enabledTools: new[] { "web_search", "code_interpreter" });
+
+var executed = GroqApiClient.GetExecutedTools(response); // which built-in tools the system ran
+```
+
+## 🌱 Optional Prompt Compression (v2.1)
+
+A "greening"/cost feature: reduce a prompt's token footprint before sending. This is **opt-in lossy
+token reduction** (the model reads the transformed text — there is no reversible decompress), so weigh
+the quality/cost trade-off. When no compressor is supplied, prompts are sent unchanged.
+
+```csharp
+// Zero-cost, near-lossless: collapses redundant whitespace, no network call.
+var provider = new GroqLlmProvider(apiKey, GroqModels.GptOss120B, new WhitespaceCompressor());
+
+// Optional LLM-based compression for LARGE prompts (adds a call; net-negative on small prompts,
+// so it no-ops below MinCharsToCompress):
+var llmCompressor = new LlmSummarizingCompressor(new GroqApiClient(apiKey), GroqModels.GptOss20B);
+var provider2 = new GroqLlmProvider(apiKey, GroqModels.GptOss120B, llmCompressor);
+```
+
+Implement `IPromptCompressor` for a custom strategy. Measure the effect with `GroqUsage.PromptTokens`
+before/after rather than assuming savings.
+
+### Ecosystem note
+If you're building a **coding agent** on top of this library, most of your prompt tokens are usually
+*source code context*, not prose. Tools like [jcodemunch-mcp](https://github.com/jgravelle) can rank and
+pack the relevant code under a token budget **upstream** — before the prompt reaches Groq — which
+typically saves far more than compressing the assembled prompt. That is complementary to, not a
+replacement for, the `IPromptCompressor` seam above.
 
 ## ⚙️ Advanced Configuration
 
@@ -487,7 +559,7 @@ groqApi.SetCustomHeader("Groq-Model-Version", "latest");
 // Available tiers: auto, on_demand, flex, performance
 var request = new JsonObject
 {
-    ["model"] = GroqModels.Llama33_70B,
+    ["model"] = GroqModels.GptOss120B,
     ["service_tier"] = ServiceTiers.Performance,
     // ...
 };
@@ -515,9 +587,13 @@ catch (JsonException e)
 v2.0 is backwards compatible. Existing code will continue to work. New features are additive.
 
 **Notable changes:**
-- Default vision model changed from `llama-3.2-90b-vision-preview` to `meta-llama/llama-4-scout-17b-16e-instruct`
 - `max_tokens` deprecated in favor of `max_completion_tokens`
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
+
+### v2.1 (2026-07)
+- **Model catalog refreshed** to Groq's current lineup. Decommissioned/deprecated IDs (Kimi K2, Llama 4 Scout/Maverick, Qwen3-32B, Llama 3.2 vision) are now marked `[Obsolete]`.
+- **Default vision model is now `qwen/qwen3.6-27b`** (the Llama 4 vision models are deprecated; `gpt-oss-120b` is text-only).
+- **Corrected Orpheus TTS voices** — the previous voice constants were PlayAI names and did not work with Orpheus. Use `autumn/diana/hannah/austin/daniel/troy` (English) and `abdullah/fahad/sultan/lulwa/noura/aisha` (Arabic). Orpheus output is WAV-only.
 
 ## 🛠️ Contributing
 


### PR DESCRIPTION
Re-release audit of the library against Groq's current API (last publish v2.0.0, 2026-01-26). Model IDs verified against console.groq.com/docs/models, /deprecations, and /text-to-speech/orpheus as of 2026-07-12.

## Correctness (parts of v2.0.0 were broken vs. current Groq API)
- **Model catalog:** added `qwen/qwen3.6-27b`; marked decommissioned/deprecated IDs `[Obsolete]` with replacement guidance — Kimi K2 (gone 2026-04-15), Llama 4 Maverick (gone 2026-03-09), Llama 4 Scout & Qwen3-32B (shut down 2026-07-17), Llama 3.2 vision.
- **Vision defaults** across 5 client methods + interface changed from the deprecating `llama-4-scout` to `qwen/qwen3.6-27b` (`gpt-oss-120b` is text-only, not a vision drop-in).
- **Orpheus TTS voices:** the shipped `OrpheusVoices` constants (`tara/leah/jess/...`) were **PlayAI** names that don't work with Orpheus. Replaced with the real roster (`autumn/diana/hannah/austin/daniel/troy`, `abdullah/fahad/sultan/lulwa/noura/aisha`). Corrected TTS docs (WAV-only output, 200-char cap).
- README model table, voice reference, and examples refreshed.

## New capabilities
- **`GroqChatOptions`** — strongly-typed `service_tier`, `seed`, `stop`, `tool_choice`, `parallel_tool_calls`, `include_reasoning`, `stream_options`, etc., plus a `CreateChatCompletionAsync(messages, model, options)` overload.
- **`GroqUsage`** — parses token counts, timing, `prompt_tokens_details.cached_tokens` (prompt caching), and `x_groq.id`.
- **URL-based STT** — `CreateTranscriptionFromUrlAsync` / `CreateTranslationFromUrlAsync`.
- **Compound refresh** — `enabledTools` → `compound_custom.tools.enabled_tools`; `GetExecutedTools` helper.

## Issue #4 (opt-in, default off)
- `IPromptCompressor` seam with `WhitespaceCompressor` (zero-cost) and optional `LlmSummarizingCompressor`, wired into `GroqLlmProvider`. Reframed as lossy token reduction + usage analytics (see issue). Closes #4.

## Deferred to v2.2
Batch/Files API, Responses API, built-in-tools modeling, remote MCP — larger new surfaces, no urgency.

## Verification
- `dotnet build` clean (0 warnings, 0 errors) on net8.0.
- 26/26 offline assertions pass exercising `GroqChatOptions.ApplyTo`, `GroqUsage.FromResponse` (incl. cached_tokens/x_groq.id), `WhitespaceCompressor`, and `GetExecutedTools`.
- Live-network paths (actual `service_tier`, Orpheus WAV, STT `url`) require an API key and were not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)