### PR TITLE
Fix: InvariantCulture for transcription/translation temperature (v2.1.1)

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -307,7 +307,7 @@ namespace GroqApiLibrary
                 content.Add(new StringContent(language), "language");
 
             if (temperature.HasValue)
-                content.Add(new StringContent(temperature.Value.ToString()), "temperature");
+                content.Add(new StringContent(temperature.Value.ToString(CultureInfo.InvariantCulture)), "temperature");
 
             var response = await _httpClient.PostAsync(BaseUrl + TranscriptionsEndpoint, content);
             response.EnsureSuccessStatusCode();
@@ -327,7 +327,7 @@ namespace GroqApiLibrary
             content.Add(new StringContent(responseFormat), "response_format");
 
             if (temperature.HasValue)
-                content.Add(new StringContent(temperature.Value.ToString()), "temperature");
+                content.Add(new StringContent(temperature.Value.ToString(CultureInfo.InvariantCulture)), "temperature");
 
             var response = await _httpClient.PostAsync(BaseUrl + TranslationsEndpoint, content);
             response.EnsureSuccessStatusCode();

--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -14,9 +14,9 @@
 		<PackageIcon>g_icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Groq, API, Windows, .NET, Core, AI, LLM, TTS, Whisper, Vision, Tool-Calling, Structured-Outputs</PackageTags>
-		<AssemblyVersion>2.1.0.0</AssemblyVersion>
-		<FileVersion>2.1.0.0</FileVersion>
-		<Version>2.1.0</Version>
+		<AssemblyVersion>2.1.1.0</AssemblyVersion>
+		<FileVersion>2.1.1.0</FileVersion>
+		<Version>2.1.1</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -590,6 +590,9 @@ v2.0 is backwards compatible. Existing code will continue to work. New features 
 - `max_tokens` deprecated in favor of `max_completion_tokens`
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
 
+### v2.1.1 (2026-07)
+- **Fix:** audio transcription/translation now format the `temperature` value with `InvariantCulture`, so requests no longer send `0,5` (and get rejected) on comma-decimal locales.
+
 ### v2.1 (2026-07)
 - **Model catalog refreshed** to Groq's current lineup. Decommissioned/deprecated IDs (Kimi K2, Llama 4 Scout/Maverick, Qwen3-32B, Llama 3.2 vision) are now marked `[Obsolete]`.
 - **Default vision model is now `qwen/qwen3.6-27b`** (the Llama 4 vision models are deprecated; `gpt-oss-120b` is text-only).


### PR DESCRIPTION
Patch release **2.1.1**. Closes #18.

## Problem
`CreateTranscriptionAsync` / `CreateTranslationAsync` formatted the multipart `temperature` field with `temperature.Value.ToString()` — no `InvariantCulture`. On comma-decimal locales (de-DE, fr-FR, …) this sends `"0,5"`, which the API can reject/misparse. The v2.1 URL-based methods already used `InvariantCulture`; the original two did not.

## Fix
Use `temperature.Value.ToString(CultureInfo.InvariantCulture)` in both methods. Bump to 2.1.1; README changelog updated.

## Verification
- `dotnet build` clean (0/0).
- Culture proof under `de-DE`: old `.ToString()` → `"0,5"`, fixed `.ToString(InvariantCulture)` → `"0.5"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)