### PR TITLE
Add Batch API support (#16)

### DIFF
--- a/Batch.cs
+++ b/Batch.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// Valid target endpoints for a batch (the per-line <c>url</c> and the batch <c>endpoint</c>).
+    /// Note these are the OpenAI-style <c>/v1/...</c> paths, not <c>/openai/v1/...</c>.
+    /// </summary>
+    public static class BatchEndpoints
+    {
+        public const string ChatCompletions = "/v1/chat/completions";
+        public const string Transcriptions = "/v1/audio/transcriptions";
+        public const string Translations = "/v1/audio/translations";
+    }
+
+    /// <summary>
+    /// Builds a JSONL batch-input file from individual requests, ready to hand to
+    /// <see cref="GroqApiClient.UploadFileAsync"/>. Each request becomes one line
+    /// <c>{ custom_id, method, url, body }</c>.
+    /// </summary>
+    public sealed class BatchRequestBuilder
+    {
+        private readonly string _url;
+        private readonly List<JsonObject> _lines = new();
+
+        /// <param name="url">Target endpoint applied to every request, e.g. <see cref="BatchEndpoints.ChatCompletions"/>.</param>
+        public BatchRequestBuilder(string url = BatchEndpoints.ChatCompletions) => _url = url;
+
+        /// <summary>Number of requests added so far.</summary>
+        public int Count => _lines.Count;
+
+        /// <summary>
+        /// Adds one request. <paramref name="customId"/> must be unique within the batch and is echoed
+        /// back on the corresponding output line so you can correlate results.
+        /// </summary>
+        public BatchRequestBuilder Add(string customId, JsonObject body, string method = "POST")
+        {
+            _lines.Add(new JsonObject
+            {
+                ["custom_id"] = customId,
+                ["method"] = method,
+                ["url"] = _url,
+                // Clone so a body that is already parented elsewhere is safe to pass.
+                ["body"] = JsonNode.Parse(body.ToJsonString())
+            });
+            return this;
+        }
+
+        /// <summary>Serializes the accumulated requests to JSONL (one JSON object per line).</summary>
+        public string Build() => string.Join("\n", _lines.Select(l => l.ToJsonString()));
+
+        /// <summary>Serializes to UTF-8 JSONL bytes.</summary>
+        public byte[] BuildBytes() => Encoding.UTF8.GetBytes(Build());
+
+        /// <summary>Serializes to a UTF-8 JSONL stream, suitable for <see cref="GroqApiClient.UploadFileAsync"/>.</summary>
+        public Stream BuildStream() => new MemoryStream(BuildBytes());
+    }
+
+    /// <summary>One parsed line of a batch output file.</summary>
+    public sealed class BatchOutputLine
+    {
+        /// <summary>Provider-assigned id for this result line.</summary>
+        public string? Id { get; set; }
+
+        /// <summary>The <c>custom_id</c> supplied in the input, for correlation.</summary>
+        public string? CustomId { get; set; }
+
+        /// <summary>HTTP status code of the individual request.</summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>Groq request id for the individual request.</summary>
+        public string? RequestId { get; set; }
+
+        /// <summary>The response body (e.g. a chat-completion object). Null on error lines.</summary>
+        public JsonObject? Body { get; set; }
+
+        /// <summary>Error detail when the request failed; null on success.</summary>
+        public JsonNode? Error { get; set; }
+
+        /// <summary>True when there was no error and the status code is 2xx.</summary>
+        public bool IsSuccess => Error is null && StatusCode is >= 200 and < 300;
+    }
+
+    /// <summary>Helpers for reading batch output JSONL (from the output/error file content).</summary>
+    public static class BatchJsonl
+    {
+        /// <summary>Parses batch output JSONL into typed lines. Blank lines are skipped.</summary>
+        public static List<BatchOutputLine> ParseOutput(string jsonl)
+        {
+            var result = new List<BatchOutputLine>();
+            if (string.IsNullOrEmpty(jsonl)) return result;
+
+            foreach (var raw in jsonl.Split('\n'))
+            {
+                var line = raw.Trim();
+                if (line.Length == 0) continue;
+                if (JsonNode.Parse(line) is not JsonObject o) continue;
+
+                var resp = o["response"] as JsonObject;
+                result.Add(new BatchOutputLine
+                {
+                    Id = o["id"]?.GetValue<string>(),
+                    CustomId = o["custom_id"]?.GetValue<string>(),
+                    StatusCode = resp?["status_code"] is JsonValue sc && sc.TryGetValue<int>(out var i) ? i : null,
+                    RequestId = resp?["request_id"]?.GetValue<string>(),
+                    Body = resp?["body"] as JsonObject,
+                    Error = o["error"]
+                });
+            }
+            return result;
+        }
+
+        /// <summary>Parses batch output JSONL from raw UTF-8 bytes (e.g. from <see cref="GroqApiClient.GetFileContentAsync"/>).</summary>
+        public static List<BatchOutputLine> ParseOutput(byte[] bytes) => ParseOutput(Encoding.UTF8.GetString(bytes));
+    }
+
+    /// <summary>
+    /// Strongly-typed view of a batch object, parsed from the create/retrieve response.
+    /// Verified against console.groq.com/docs/batch as of 2026-07-12.
+    /// </summary>
+    public sealed class GroqBatch
+    {
+        public string? Id { get; set; }
+        public string? Status { get; set; }
+        public string? Endpoint { get; set; }
+        public string? CompletionWindow { get; set; }
+        public string? InputFileId { get; set; }
+        public string? OutputFileId { get; set; }
+        public string? ErrorFileId { get; set; }
+
+        public int RequestsTotal { get; set; }
+        public int RequestsCompleted { get; set; }
+        public int RequestsFailed { get; set; }
+
+        public long? CreatedAt { get; set; }
+        public long? ExpiresAt { get; set; }
+        public long? CompletedAt { get; set; }
+        public long? FailedAt { get; set; }
+        public long? CancelledAt { get; set; }
+        public long? ExpiredAt { get; set; }
+
+        /// <summary>Raw errors object from the batch, if any.</summary>
+        public JsonNode? Errors { get; set; }
+
+        /// <summary>True once the batch has reached a terminal state and will not change further.</summary>
+        public bool IsTerminal => Status is "completed" or "failed" or "expired" or "cancelled";
+
+        /// <summary>True when the batch finished successfully.</summary>
+        public bool IsCompleted => Status == "completed";
+
+        public static GroqBatch? FromResponse(JsonObject? o)
+        {
+            if (o is null) return null;
+            var counts = o["request_counts"] as JsonObject;
+            return new GroqBatch
+            {
+                Id = o["id"]?.GetValue<string>(),
+                Status = o["status"]?.GetValue<string>(),
+                Endpoint = o["endpoint"]?.GetValue<string>(),
+                CompletionWindow = o["completion_window"]?.GetValue<string>(),
+                InputFileId = o["input_file_id"]?.GetValue<string>(),
+                OutputFileId = o["output_file_id"]?.GetValue<string>(),
+                ErrorFileId = o["error_file_id"]?.GetValue<string>(),
+                RequestsTotal = GetInt(counts, "total"),
+                RequestsCompleted = GetInt(counts, "completed"),
+                RequestsFailed = GetInt(counts, "failed"),
+                CreatedAt = GetLong(o, "created_at"),
+                ExpiresAt = GetLong(o, "expires_at"),
+                CompletedAt = GetLong(o, "completed_at"),
+                FailedAt = GetLong(o, "failed_at"),
+                CancelledAt = GetLong(o, "cancelled_at"),
+                ExpiredAt = GetLong(o, "expired_at"),
+                Errors = o["errors"]
+            };
+        }
+
+        private static int GetInt(JsonObject? o, string key)
+            => o?[key] is JsonValue v && v.TryGetValue<int>(out var i) ? i : 0;
+
+        private static long? GetLong(JsonObject o, string key)
+            => o[key] is JsonValue v && v.TryGetValue<long>(out var l) ? l : null;
+    }
+}

--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -20,6 +20,7 @@ namespace GroqApiLibrary
         private const string TranslationsEndpoint = "/audio/translations";
         private const string SpeechEndpoint = "/audio/speech";
         private const string FilesEndpoint = "/files";
+        private const string BatchesEndpoint = "/batches";
 
         // Vision-capable models. Verified against console.groq.com/docs/models &amp; /deprecations (2026-07-12).
         // qwen/qwen3.6-27b is the current recommended vision model. The Llama 4 / Llama 3.2 vision
@@ -810,6 +811,78 @@ namespace GroqApiLibrary
         {
             var response = await _httpClient.DeleteAsync($"{BaseUrl}{FilesEndpoint}/{fileId}");
             response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        #endregion
+
+        #region Batch
+
+        // Like Files, the Batch API requires an eligible Groq plan (else 403 not_available_for_plan).
+        // Batches run asynchronously (50% discount) and have their own rate limits; they do not
+        // accept a service_tier. See BatchRequestBuilder / BatchJsonl / GroqBatch for helpers.
+
+        /// <summary>
+        /// Creates a batch job that processes an uploaded JSONL input file asynchronously.
+        /// </summary>
+        /// <param name="inputFileId">Id of an uploaded file (see <see cref="UploadFileAsync"/>).</param>
+        /// <param name="endpoint">Target endpoint for every line, e.g. <see cref="BatchEndpoints.ChatCompletions"/>.</param>
+        /// <param name="completionWindow">Processing window from "24h" to "7d".</param>
+        /// <param name="metadata">Optional caller metadata echoed back on the batch object.</param>
+        public async Task<JsonObject?> CreateBatchAsync(string inputFileId, string endpoint,
+            string completionWindow = "24h", JsonObject? metadata = null)
+        {
+            var request = new JsonObject
+            {
+                ["input_file_id"] = inputFileId,
+                ["endpoint"] = endpoint,
+                ["completion_window"] = completionWindow
+            };
+            if (metadata is not null)
+                request["metadata"] = JsonNode.Parse(metadata.ToJsonString());
+
+            var response = await _httpClient.PostAsJsonAsync(BaseUrl + BatchesEndpoint, request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException($"Batch creation failed with status code {response.StatusCode}. Response content: {errorContent}");
+            }
+
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// Retrieves a batch by id. Parse with <see cref="GroqBatch.FromResponse"/> to poll status.
+        /// </summary>
+        public async Task<JsonObject?> GetBatchAsync(string batchId)
+        {
+            var response = await _httpClient.GetAsync($"{BaseUrl}{BatchesEndpoint}/{batchId}");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// Lists batch jobs. Returns { object: "list", data: [ ... ] }.
+        /// </summary>
+        public async Task<JsonObject?> ListBatchesAsync()
+        {
+            var response = await _httpClient.GetAsync(BaseUrl + BatchesEndpoint);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// Requests cancellation of an in-progress batch.
+        /// </summary>
+        public async Task<JsonObject?> CancelBatchAsync(string batchId)
+        {
+            var response = await _httpClient.PostAsync($"{BaseUrl}{BatchesEndpoint}/{batchId}/cancel", null);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException($"Batch cancel failed with status code {response.StatusCode}. Response content: {errorContent}");
+            }
+
             return await response.Content.ReadFromJsonAsync<JsonObject>();
         }
 

--- a/IGroqApiClient.cs
+++ b/IGroqApiClient.cs
@@ -245,6 +245,31 @@ namespace GroqApiLibrary
 
         #endregion
 
+        #region Batch
+
+        /// <summary>
+        /// Creates a batch job over an uploaded JSONL input file. Endpoint values are in <see cref="BatchEndpoints"/>.
+        /// </summary>
+        Task<JsonObject?> CreateBatchAsync(string inputFileId, string endpoint,
+            string completionWindow = "24h", JsonObject? metadata = null);
+
+        /// <summary>
+        /// Retrieves a batch by id (parse with <see cref="GroqBatch.FromResponse"/>).
+        /// </summary>
+        Task<JsonObject?> GetBatchAsync(string batchId);
+
+        /// <summary>
+        /// Lists batch jobs.
+        /// </summary>
+        Task<JsonObject?> ListBatchesAsync();
+
+        /// <summary>
+        /// Requests cancellation of an in-progress batch.
+        /// </summary>
+        Task<JsonObject?> CancelBatchAsync(string batchId);
+
+        #endregion
+
         #region Tool Use
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -545,6 +545,51 @@ pack the relevant code under a token budget **upstream** — before the prompt r
 typically saves far more than compressing the assembled prompt. That is complementary to, not a
 replacement for, the `IPromptCompressor` seam above.
 
+## 📦 Files & Batch Processing (v2.2)
+
+Run large jobs asynchronously at a 50% discount. Build a JSONL input with `BatchRequestBuilder`,
+upload it via the Files API, create a batch, poll until terminal, then download and parse the output.
+
+> ⚠️ The Files and Batch APIs require an eligible Groq plan. On unsupported plans the API returns
+> `403 not_available_for_plan`.
+
+```csharp
+// 1) Build JSONL input (one line per request; custom_id correlates results)
+var builder = new BatchRequestBuilder(BatchEndpoints.ChatCompletions)
+    .Add("req-1", new JsonObject {
+        ["model"] = GroqModels.GptOss20B,
+        ["messages"] = new JsonArray { new JsonObject { ["role"]="user", ["content"]="Summarize X" } }
+    })
+    .Add("req-2", new JsonObject {
+        ["model"] = GroqModels.GptOss20B,
+        ["messages"] = new JsonArray { new JsonObject { ["role"]="user", ["content"]="Summarize Y" } }
+    });
+
+// 2) Upload + create the batch
+var file  = await groqApi.UploadFileAsync(builder.BuildStream(), "batch_input.jsonl");
+var batch = GroqBatch.FromResponse(
+    await groqApi.CreateBatchAsync(file!["id"]!.GetValue<string>(), BatchEndpoints.ChatCompletions, "24h"));
+
+// 3) Poll until terminal
+while (!batch!.IsTerminal)
+{
+    await Task.Delay(TimeSpan.FromSeconds(30));
+    batch = GroqBatch.FromResponse(await groqApi.GetBatchAsync(batch.Id!));
+}
+
+// 4) Download + parse results
+if (batch.IsCompleted)
+{
+    var bytes   = await groqApi.GetFileContentAsync(batch.OutputFileId!);
+    var results = BatchJsonl.ParseOutput(bytes);   // List<BatchOutputLine>
+    foreach (var r in results)
+        Console.WriteLine($"{r.CustomId}: {(r.IsSuccess ? r.Body?["choices"]?[0]?["message"]?["content"] : r.Error)}");
+}
+```
+
+Files API methods are also available directly: `UploadFileAsync`, `ListFilesAsync`, `GetFileAsync`,
+`GetFileContentAsync` / `GetFileContentStreamAsync`, `DeleteFileAsync`.
+
 ## ⚙️ Advanced Configuration
 
 ### Custom Headers (e.g., Compound versioning)


### PR DESCRIPTION
Part of the **v2.2** milestone. Closes #16. Depends on #15 (Files API, merged).

## What
Async bulk processing (50% discount). Endpoints on `GroqApiClient` + `IGroqApiClient`:
- `CreateBatchAsync(inputFileId, endpoint, completionWindow="24h", metadata?)`
- `GetBatchAsync(id)`, `ListBatchesAsync()`, `CancelBatchAsync(id)`

Ergonomics in `Batch.cs`:
- `BatchEndpoints` — valid `/v1/...` endpoint constants
- `BatchRequestBuilder` — assemble the JSONL input file (`.Add(customId, body)` → `.BuildStream()`), bodies are cloned so reuse is safe
- `BatchJsonl.ParseOutput` — parse output JSONL into typed `BatchOutputLine` (custom_id, status_code, body, error, `IsSuccess`)
- `GroqBatch` — typed status/file-ids/request-counts with `IsTerminal` / `IsCompleted`

## Verification
- `dotnet build` clean (0/0).
- **23 offline assertions** pass over the builder, output parser, and `GroqBatch.FromResponse` (the bulk of the logic/risk).
- Contract verified against console.groq.com/docs/batch (endpoints, request/response shapes, status values, JSONL formats). Cancel path uses the standard OpenAI-compatible `POST /batches/{id}/cancel`.
- ⚠️ **Live round-trip not exercised** — Batch requires an eligible Groq plan (`403 not_available_for_plan` on this account). Shipping on docs-conformance per decision; README + code note the plan requirement.

## Notes
No release yet — completes the v2.2 Files+Batch flagship. Remaining v2.2: #17 (streaming usage), #19 (model constants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)