### PR TITLE
Streaming options/usage overload (#17) + model constants (#19)

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -124,6 +124,18 @@ namespace GroqApiLibrary
         }
 
         /// <summary>
+        /// Streams a chat completion from messages plus optional strongly-typed parameters
+        /// (see <see cref="GroqChatOptions"/>). Set <see cref="GroqChatOptions.StreamIncludeUsage"/> to
+        /// receive a final chunk carrying <c>usage</c> (read it with <see cref="GroqUsage.FromResponse"/>).
+        /// </summary>
+        public IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonArray messages, string model, GroqChatOptions? options = null)
+        {
+            var request = new JsonObject { ["model"] = model, ["messages"] = messages };
+            options?.ApplyTo(request);
+            return CreateChatCompletionStreamAsync(request);
+        }
+
+        /// <summary>
         /// Creates a chat completion with structured output using JSON Schema.
         /// Supports strict mode for guaranteed schema compliance on supported models (GPT-OSS 20B/120B).
         /// </summary>
@@ -1076,6 +1088,9 @@ namespace GroqApiLibrary
 
         // Qwen 3.6 27B: current recommended reasoning + vision-capable model (131K context).
         public const string Qwen36_27B = "qwen/qwen3.6-27b";
+
+        // Allam 2 7B: Arabic-focused language model.
+        public const string Allam2_7B = "allam-2-7b";
 
         // Compound agentic systems (used via the chat endpoint by setting the model).
         public const string Compound = "groq/compound";

--- a/IGroqApiClient.cs
+++ b/IGroqApiClient.cs
@@ -23,6 +23,12 @@ namespace GroqApiLibrary
         IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request);
 
         /// <summary>
+        /// Streams a chat completion from messages plus optional parameters (see <see cref="GroqChatOptions"/>).
+        /// Set <see cref="GroqChatOptions.StreamIncludeUsage"/> to receive a final chunk carrying usage.
+        /// </summary>
+        IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonArray messages, string model, GroqChatOptions? options = null);
+
+        /// <summary>
         /// Creates a chat completion with structured JSON output using JSON Schema.
         /// </summary>
         Task<JsonObject?> CreateChatCompletionWithStructuredOutputAsync(

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ if (modelsResponse?["data"] is JsonArray models)
 | `GroqModels.GptOss120B` | openai/gpt-oss-120b | **Recommended default.** Reasoning + built-in tools, structured outputs (strict). Text-only. |
 | `GroqModels.GptOss20B` | openai/gpt-oss-20b | Faster. Structured outputs (strict). |
 | `GroqModels.Qwen36_27B` | qwen/qwen3.6-27b | Reasoning + **vision**, 131k context |
+| `GroqModels.Allam2_7B` | allam-2-7b | Arabic-focused language model |
 
 ### Vision/Multimodal Models
 | Constant | Model ID | Notes |


### PR DESCRIPTION
Part of the **v2.2** milestone. Closes #17, closes #19.

## #17 — streaming: options + usage
- New overload `CreateChatCompletionStreamAsync(JsonArray messages, string model, GroqChatOptions? options = null)` on `GroqApiClient` + `IGroqApiClient`.
- Applies `GroqChatOptions`; with `StreamIncludeUsage = true`, the final chunk carries `usage`, readable via `GroqUsage.FromResponse`.
- **Verified live:** 26 chunks streamed (`"1, 2, 3, 4, 5."`) and the final chunk's usage parsed (p=79/c=33/t=112).

## #19 — model constants
- Added `GroqModels.Allam2_7B` = `allam-2-7b` — present in the account's live `/models` catalog but previously missing.
- **Deliberately did NOT add** `minimaxai/minimax-m2.5` or `qwen/qwen3-vl-32b-instruct`: neither appears in the live catalog (they were unconfirmed search-snippet IDs). Adding unverifiable model constants would be a footgun; noted here for the record.

## Verification
- `dotnet build` clean (0/0). Streaming verified live; model list checked against the live `/models` endpoint.

This is the **last code** for v2.2 — after merge I'll bump to 2.2.0 and cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)