### PR TITLE
fix(ci): bump publish.yml actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -35,7 +35,7 @@ jobs:
         run: dotnet pack GroqApiLibrary.csproj -c Release --no-build -o ${{ github.workspace }}/artifacts
 
       - name: NuGet login (Trusted Publishing)
-        uses: NuGet/login@v1
+        uses: NuGet/login@v1.2.0
         id: login
         with:
           user: JGravelle   # NuGet.org username


### PR DESCRIPTION
Closes #14.

## Summary
`publish.yml` pinned `actions/checkout@v4`, `actions/setup-dotnet@v4`, and `NuGet/login@v1` — all of which declare `using: node20` at those tags, triggering GitHub's Node 20 deprecation annotation (non-blocking today since GitHub force-runs them on Node 24, but the pins should be current).

## Changes
- `actions/checkout@v4` → `@v7`
- `actions/setup-dotnet@v4` → `@v5` (v5.0.0's own release notes list "Breaking Changes: Upgrade to Node.js 24" as the headline change)
- `NuGet/login@v1` → `@v1.2.0` — the `v1` tag turned out to be frozen at the original node20-era commit rather than a floating major alias; confirmed via the GitHub API that `refs/tags/v1` and `refs/tags/v1.2.0` point to different commits

## Testing Done
Confirmed via the GitHub API (`contents/action.yml?ref=<tag>` on each pinned tag) that all three now declare `using: node24`. Verified the edited YAML parses cleanly.

I did not re-run the actual publish workflow via `workflow_dispatch`, since that requires the repo's NuGet Trusted Publishing OIDC trust relationship (Owner/Repo/Workflow-scoped on nuget.org), which only applies on the base repo — a fork's run would just fail on that step regardless of whether the action-version fix is correct. Happy to have a maintainer re-run it post-merge per the issue's own verification step.

## Performance Impact
N/A — CI-only change, no runtime code touched.