### PR TITLE
feat(di): AddGroqApiClient IServiceCollection extension (closes #28)

### DIFF
--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -22,6 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
 		<None Include="README.md" Pack="True" PackagePath="\" />
 		<None Include="g_icon.png" Pack="True" PackagePath="\" />
 	</ItemGroup>

--- a/GroqServiceCollectionExtensions.cs
+++ b/GroqServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net.Http;
+using GroqApiLibrary;
+
+// Placed in the conventional DI namespace so a single `using Microsoft.Extensions.DependencyInjection;`
+// (already present in typical ASP.NET Core / Generic Host projects) surfaces these extensions.
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions for registering <see cref="IGroqApiClient"/>.
+    /// </summary>
+    public static class GroqServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers <see cref="IGroqApiClient"/> (implemented by <see cref="GroqApiClient"/>) with a
+        /// pooled <see cref="HttpClient"/> managed by <see cref="IHttpClientFactory"/>, which avoids the
+        /// socket-exhaustion problems of manually newing up <see cref="HttpClient"/> per request.
+        /// The Groq bearer token is applied from <paramref name="apiKey"/>.
+        /// </summary>
+        /// <param name="services">The service collection to add the client to.</param>
+        /// <param name="apiKey">The Groq API key used to authenticate requests.</param>
+        /// <returns>
+        /// An <see cref="IHttpClientBuilder"/> so callers can further configure the underlying client
+        /// (e.g. <c>.SetHandlerLifetime(...)</c>, resilience/retry handlers).
+        /// </returns>
+        public static IHttpClientBuilder AddGroqApiClient(this IServiceCollection services, string apiKey)
+            => services.AddGroqApiClient(apiKey, configureClient: null);
+
+        /// <summary>
+        /// Registers <see cref="IGroqApiClient"/> as above, with a hook to customize the managed
+        /// <see cref="HttpClient"/> (for example to set <see cref="HttpClient.Timeout"/> or a proxy
+        /// <see cref="HttpClient.BaseAddress"/>). The configuration runs before the client's auth header
+        /// is applied, so callers should not overwrite the <c>Authorization</c> header here.
+        /// </summary>
+        /// <param name="services">The service collection to add the client to.</param>
+        /// <param name="apiKey">The Groq API key used to authenticate requests.</param>
+        /// <param name="configureClient">Optional callback to configure the managed <see cref="HttpClient"/>.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/> for further configuration.</returns>
+        public static IHttpClientBuilder AddGroqApiClient(
+            this IServiceCollection services,
+            string apiKey,
+            Action<HttpClient>? configureClient)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("A Groq API key is required.", nameof(apiKey));
+
+            return services.AddHttpClient<IGroqApiClient, GroqApiClient>((httpClient, _) =>
+            {
+                configureClient?.Invoke(httpClient);
+                return new GroqApiClient(apiKey, httpClient);
+            });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -593,6 +593,31 @@ Files API methods are also available directly: `UploadFileAsync`, `ListFilesAsyn
 
 ## ⚙️ Advanced Configuration
 
+### Dependency Injection (ASP.NET Core / Generic Host)
+
+Register `IGroqApiClient` with a factory-managed, pooled `HttpClient` (avoids socket exhaustion) via `AddGroqApiClient`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services.AddGroqApiClient(builder.Configuration["Groq:ApiKey"]!);
+
+// Optional: customize the managed HttpClient (timeout, proxy, etc.)
+builder.Services.AddGroqApiClient(apiKey, http => http.Timeout = TimeSpan.FromSeconds(60));
+```
+
+Then inject `IGroqApiClient` anywhere:
+
+```csharp
+public class MyService(IGroqApiClient groq)
+{
+    public Task<JsonObject?> AskAsync(JsonArray messages) =>
+        groq.CreateChatCompletionAsync(messages, GroqModels.Llama33_70B);
+}
+```
+
+`AddGroqApiClient` returns the `IHttpClientBuilder`, so you can chain resilience/retry handlers or set the handler lifetime.
+
 ### Custom Headers (e.g., Compound versioning)
 
 ```csharp


### PR DESCRIPTION
Closes #28.

## Summary
Adds an idiomatic DI registration so ASP.NET Core / Generic Host consumers can wire up the client in one line, backed by a factory-managed `HttpClient`.

```csharp
builder.Services.AddGroqApiClient(apiKey);
// or, customizing the managed client:
builder.Services.AddGroqApiClient(apiKey, http => http.Timeout = TimeSpan.FromSeconds(60));
```

Registers `IGroqApiClient` -> `GroqApiClient` via `AddHttpClient<IGroqApiClient, GroqApiClient>`, so the `HttpClient` comes from `IHttpClientFactory` with pooled handlers — no socket exhaustion, no manual `HttpClient` lifetime management. The existing `GroqApiClient(string apiKey, HttpClient)` constructor made this pure wiring.

## Changes
- **`GroqServiceCollectionExtensions.cs`** (new) — in the conventional `Microsoft.Extensions.DependencyInjection` namespace so it surfaces with the `using` host projects already have. Kept in its own file so non-DI consumers aren't forced to touch it. Two overloads (apiKey-only; apiKey + `Action<HttpClient>`), both returning `IHttpClientBuilder` for further chaining (resilience handlers, handler lifetime). Guards null/empty key.
- **`GroqApiLibrary.csproj`** — adds `Microsoft.Extensions.Http` 8.0.1 (provides `AddHttpClient`; DI abstractions already arrive transitively via `Microsoft.AspNetCore.Components`).
- **`README.md`** — Dependency Injection subsection under Advanced Configuration.

## Testing Done
- `dotnet build -c Release`: clean, 0 warnings, 0 errors.
- Minimal `ServiceCollection` host: `AddGroqApiClient(apiKey, configureHttp)` -> `BuildServiceProvider()` -> `GetRequiredService<IGroqApiClient>()` resolves `GroqApiLibrary.GroqApiClient`, the configure hook runs, and a live `CreateChatCompletionAsync` call against `llama-3.1-8b-instant` returned the expected content (matches the issue's verification step).

## Performance Impact
N/A for existing code paths — new opt-in API. The registration itself improves connection reuse for DI consumers vs. per-instance `new HttpClient()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)