### PR TITLE
fix: guard Structured Outputs against streaming/tools (closes #27)

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -77,6 +77,7 @@ namespace GroqApiLibrary
 
         public async Task<JsonObject?> CreateChatCompletionAsync(JsonObject request)
         {
+            GuardStructuredOutputCompatibility(request, streaming: false);
             var response = await _httpClient.PostAsJsonAsync(BaseUrl + ChatCompletionsEndpoint, request);
 
             if (!response.IsSuccessStatusCode)
@@ -100,7 +101,14 @@ namespace GroqApiLibrary
             return CreateChatCompletionAsync(request);
         }
 
-        public async IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request)
+        public IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request)
+        {
+            // Validate eagerly: iterator methods otherwise defer the throw until first enumeration.
+            GuardStructuredOutputCompatibility(request, streaming: true);
+            return CreateChatCompletionStreamCoreAsync(request);
+        }
+
+        private async IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamCoreAsync(JsonObject request)
         {
             request["stream"] = true;
             var content = new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json");
@@ -133,6 +141,39 @@ namespace GroqApiLibrary
             var request = new JsonObject { ["model"] = model, ["messages"] = messages };
             options?.ApplyTo(request);
             return CreateChatCompletionStreamAsync(request);
+        }
+
+        /// <summary>
+        /// Guards against request combinations Groq rejects: Structured Outputs
+        /// (<c>response_format</c> of type <c>json_schema</c>) cannot be combined with streaming
+        /// or with tool use. Throws <see cref="ArgumentException"/> early with a helpful message
+        /// instead of letting the request fail server-side.
+        /// See https://console.groq.com/docs/structured-outputs.
+        /// </summary>
+        private static void GuardStructuredOutputCompatibility(JsonObject request, bool streaming)
+        {
+            if (request["response_format"] is not JsonObject responseFormat)
+                return;
+            if (responseFormat["type"] is not JsonValue typeValue
+                || !typeValue.TryGetValue<string>(out var type)
+                || type != "json_schema")
+                return;
+
+            var isStreaming = streaming
+                || (request["stream"] is JsonValue streamValue
+                    && streamValue.TryGetValue<bool>(out var streamFlag)
+                    && streamFlag);
+            if (isStreaming)
+                throw new ArgumentException(
+                    "Groq does not support Structured Outputs (response_format \"json_schema\") together with streaming. " +
+                    "Use a non-streaming call, or switch to JSON object mode (response_format type \"json_object\").",
+                    nameof(request));
+
+            if (request["tools"] is JsonArray tools && tools.Count > 0)
+                throw new ArgumentException(
+                    "Groq does not support Structured Outputs (response_format \"json_schema\") together with tool use. " +
+                    "Remove the tools, or switch to JSON object mode (response_format type \"json_object\").",
+                    nameof(request));
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ var result = await groqApi.CreateChatCompletionWithStructuredOutputAsync(
 Console.WriteLine(result?["choices"]?[0]?["message"]?["content"]?.ToString());
 ```
 
+> **Note:** Groq does not support Structured Outputs (`response_format` of type `json_schema`) together with **streaming** or **tool use**. The client guards against this: a request combining `json_schema` with `stream` or `tools` throws an `ArgumentException` up front (rather than failing server-side). If you need those features, use JSON object mode (`response_format` type `json_object`) instead.
+
 ### Reasoning/Thinking Models
 
 Enable reasoning for more thoughtful responses with Qwen3 or GPT-OSS models.


### PR DESCRIPTION
Closes #27.

## Problem
Groq does not support Structured Outputs (`response_format` of type `json_schema`) together with streaming or tool use — the docs state *"Streaming and tool use are not currently supported with Structured Outputs"* (verified against console.groq.com/docs/structured-outputs). The library previously let callers combine them and only surfaced the failure as an opaque server-side API error.

## Change
Adds `GuardStructuredOutputCompatibility(request, streaming)`: when a request carries a `json_schema` response format, it throws `ArgumentException` **up front** if the request also
- streams (the streaming entry point, or an explicit `stream: true`), or
- supplies a non-empty `tools` array,

with a message that points callers at JSON object mode (`response_format` type `json_object`).

The guard runs in both send funnels — `CreateChatCompletionAsync(JsonObject)` and `CreateChatCompletionStreamAsync(JsonObject)` — so every overload (including the strongly-typed `GroqChatOptions` ones) is covered.

The streaming method is split into an eager public method + a private iterator core, so the exception throws **immediately** on the call rather than being deferred to first enumeration (standard C# iterator gotcha — a bare `throw` in an `async IAsyncEnumerable` method wouldn't fire until the first `await foreach`).

## Testing Done
- `dotnet build -c Release`: clean, 0 warnings.
- Harness covering 6 cases, all green:
  1. structured + streaming → throws **eagerly** (before enumeration)
  2. structured + explicit `stream:true` routed through the non-stream funnel → throws
  3. structured + tools → throws
  4. structured + **empty** tools array → not guarded (guard is precise, doesn't over-fire)
  5. plain streaming (no `json_schema`) → not guarded
  6. live strict structured-output non-streaming call → still returns `{"ok":true}`

Matches the issue's verification step ("combining structured output + streaming throws with a clear message").

## Notes
Independent of #30 (DI extension); both branch off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)