### PR TITLE
feat: add AddGroqApiClient DI extension

### DIFF
--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -22,6 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
 		<None Include="README.md" Pack="True" PackagePath="\" />
 		<None Include="g_icon.png" Pack="True" PackagePath="\" />
 	</ItemGroup>

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// DI registration helpers for <see cref="IGroqApiClient"/>. Lives in its own file so
+    /// consumers who don't use dependency injection aren't forced to reference
+    /// Microsoft.Extensions.Http/DependencyInjection.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        private const string HttpClientName = "GroqApiClient";
+
+        /// <summary>
+        /// Registers <see cref="IGroqApiClient"/> backed by a named <see cref="HttpClient"/> managed
+        /// through <see cref="IHttpClientFactory"/> (avoiding socket exhaustion from manually-created
+        /// clients).
+        /// </summary>
+        public static IServiceCollection AddGroqApiClient(this IServiceCollection services, string apiKey)
+        {
+            return services.AddGroqApiClient(_ => apiKey);
+        }
+
+        /// <summary>
+        /// Registers <see cref="IGroqApiClient"/>, resolving the API key from configuration/environment
+        /// at registration time via <paramref name="apiKeyFactory"/> (e.g. reading it from
+        /// <c>IConfiguration</c> without capturing a raw key string in calling code).
+        /// </summary>
+        public static IServiceCollection AddGroqApiClient(this IServiceCollection services, Func<IServiceProvider, string> apiKeyFactory)
+        {
+            services.AddHttpClient(HttpClientName);
+            services.AddTransient<IGroqApiClient>(sp =>
+            {
+                var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName);
+                return new GroqApiClient(apiKeyFactory(sp), httpClient);
+            });
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Closes #28.

## Summary
Adds an `IServiceCollection.AddGroqApiClient(...)` extension so consumers can register `IGroqApiClient` idiomatically instead of manually constructing `GroqApiClient`.

## Changes
- `ServiceCollectionExtensions.cs` — kept in its own file (per the issue's own note) so consumers who don't use DI aren't forced onto `Microsoft.Extensions.Http`/`Microsoft.Extensions.DependencyInjection.Abstractions`.
- Two overloads:
  - `AddGroqApiClient(string apiKey)` — plain key.
  - `AddGroqApiClient(Func<IServiceProvider, string> apiKeyFactory)` — resolve the key from `IConfiguration`/config at registration time.
- Registers a **named** `HttpClient` via `AddHttpClient` (through `IHttpClientFactory`) to avoid socket exhaustion, per the issue's stated goal.
- Added `Microsoft.Extensions.Http` package reference (pulls in DI abstractions transitively).

## A real bug caught along the way
My first pass used `services.AddHttpClient<IGroqApiClient, GroqApiClient>(httpClient => new GroqApiClient(apiKey, httpClient))`. That compiles cleanly — but the lambda silently binds to the `Action<HttpClient>` overload, not a factory (object-creation is a valid C# *statement* expression, so a non-void lambda body is still assignable to `Action<T>`). The constructed `GroqApiClient` was discarded, and DI fell back to reflection-based activation of `GroqApiClient`, which crashed at runtime — `Unable to resolve service for type 'System.String'` — since `apiKey` isn't a registered service. The build was clean; only actually *running* a resolution test caught it.

Fixed by registering a named `HttpClient` and building `GroqApiClient` through an explicit factory delegate instead of relying on `AddHttpClient`'s typed-client activation.

## Testing Done
Built the library (`dotnet build`, 0 errors/warnings). Verified both overloads with a throwaway console app: constructed a `ServiceCollection`, called each overload, built the provider, and confirmed `GetRequiredService<IGroqApiClient>()` resolves a real `GroqApiClient` instance for both — including reproducing the runtime crash against the first (broken) implementation before fixing it, to confirm the verification actually catches the failure mode.

## Performance Impact
N/A — additive DI helper, no change to existing request/response code paths.