### PR TITLE
feat: guard against Structured Outputs + streaming/tools combos

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -75,8 +75,36 @@ namespace GroqApiLibrary
 
         #region Chat Completions
 
+        /// <summary>
+        /// Groq does not support Structured Outputs (response_format: json_schema) together with
+        /// streaming or tool use. Callers previously only found out via an API error; this catches
+        /// it client-side with a clearer message. Verified against console.groq.com/docs/structured-outputs
+        /// (2026-07-12): "Streaming and tool use are not currently supported with Structured Outputs."
+        /// </summary>
+        private static void ValidateStructuredOutputCompatibility(JsonObject request, bool streaming)
+        {
+            var responseFormat = request["response_format"] as JsonObject;
+            if (responseFormat?["type"]?.GetValue<string>() != "json_schema")
+                return;
+
+            var isStreaming = streaming || (request["stream"]?.GetValue<bool>() ?? false);
+            var hasTools = request["tools"] is JsonArray { Count: > 0 };
+
+            if (!isStreaming && !hasTools)
+                return;
+
+            var reasons = new List<string>();
+            if (isStreaming) reasons.Add("streaming");
+            if (hasTools) reasons.Add("tool use");
+            throw new ArgumentException(
+                $"Groq does not support Structured Outputs (response_format: json_schema) combined with {string.Join(" or ", reasons)}. " +
+                "Remove response_format, or drop streaming/tools for this request.");
+        }
+
         public async Task<JsonObject?> CreateChatCompletionAsync(JsonObject request)
         {
+            ValidateStructuredOutputCompatibility(request, streaming: false);
+
             var response = await _httpClient.PostAsJsonAsync(BaseUrl + ChatCompletionsEndpoint, request);
 
             if (!response.IsSuccessStatusCode)
@@ -102,6 +130,8 @@ namespace GroqApiLibrary
 
         public async IAsyncEnumerable<JsonObject?> CreateChatCompletionStreamAsync(JsonObject request)
         {
+            ValidateStructuredOutputCompatibility(request, streaming: true);
+
             request["stream"] = true;
             var content = new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json");
             using var requestMessage = new HttpRequestMessage(HttpMethod.Post, BaseUrl + ChatCompletionsEndpoint) { Content = content };


### PR DESCRIPTION
Closes #27.

## Summary
Groq does not support `response_format: json_schema` together with streaming or tool use. Callers previously only found out via an API error mid-request. This adds a client-side check that fails fast with a clear message.

## Changes
- `ValidateStructuredOutputCompatibility(JsonObject request, bool streaming)` — checks `response_format.type == "json_schema"` against both `stream` and a non-empty `tools` array, throws `ArgumentException` naming which incompatible option(s) were set.
- Called from both raw entry points — `CreateChatCompletionAsync(JsonObject)` and `CreateChatCompletionStreamAsync(JsonObject)` — which every convenience method (`CreateChatCompletionWithStructuredOutputAsync`, the `GroqChatOptions` overloads, etc.) funnels through, so this covers the whole public surface from one place instead of scattering checks per-method.
- Verified the incompatibility still holds against console.groq.com/docs/structured-outputs before enforcing, per the issue's own note ("Streaming and tool use are not currently supported with Structured Outputs.").

## Testing Done
`dotnet build` clean (0 errors/warnings). Wrote a throwaway console app exercising 4 cases against the built library:
1. `json_schema` + `tools` (non-streaming) → threw `ArgumentException` ✅
2. `json_schema` + streaming → threw `ArgumentException` ✅
3. `json_schema` alone (no streaming/tools) → guard did **not** fire (request proceeded to the HTTP call, which failed for an unrelated network reason against a fake key/host — confirms no false positive) ✅
4. `tools` alone, no `json_schema` (normal tool-calling) → guard did **not** fire ✅

## Performance Impact
N/A — one cheap dictionary-lookup-equivalent check added to two call paths, no change to the request/response payload itself.