### PR TITLE
Add built-in server-side tools helpers (closes #26)

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -352,8 +352,9 @@ namespace GroqApiLibrary
         }
 
         /// <summary>
-        /// Returns the <c>executed_tools</c> array from a Compound response (the built-in tools the
-        /// system ran while producing the answer), or null if none is present.
+        /// Returns the raw <c>executed_tools</c> array — the built-in tools the model ran while producing
+        /// the answer — or null if none is present. Works for both Compound systems and gpt-oss built-in
+        /// tools (they share this location). For a typed projection, use <see cref="GroqExecutedTool.FromResponse"/>.
         /// </summary>
         public static JsonArray? GetExecutedTools(JsonObject? response)
             => response?["choices"]?[0]?["message"]?["executed_tools"] as JsonArray;

--- a/GroqBuiltInTools.cs
+++ b/GroqBuiltInTools.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// Builders and identifiers for Groq's built-in, server-side tools — so callers can add them to a
+    /// request without hand-writing raw JSON.
+    /// <para>
+    /// Two families: <b>gpt-oss</b> tools go in the request's <c>tools</c> array as <c>{ "type": "..." }</c>
+    /// entries (use <see cref="BrowserSearch"/> / <see cref="CodeInterpreter"/>); <b>Compound</b> systems
+    /// (<c>groq/compound</c>, <c>groq/compound-mini</c>) enable tools by name via
+    /// <c>compound_custom.tools.enabled_tools</c> — pass the <see cref="Compound"/> constants to
+    /// <see cref="GroqApiClient.CreateCompoundCompletionAsync"/>'s <c>enabledTools</c> parameter.
+    /// </para>
+    /// Whatever the model runs surfaces in the response's <c>executed_tools</c>; read it with
+    /// <see cref="GroqExecutedTool.FromResponse"/>.
+    /// <para>Verified against console.groq.com/docs (browser-search, code-execution) on 2026-07-13.</para>
+    /// </summary>
+    public static class GroqBuiltInTools
+    {
+        /// <summary>
+        /// A <c>browser_search</c> tool entry for the <c>tools</c> array. gpt-oss models only
+        /// (<c>openai/gpt-oss-20b</c>, <c>openai/gpt-oss-120b</c>, <c>openai/gpt-oss-safeguard-20b</c>).
+        /// Cannot be combined with Structured Outputs.
+        /// </summary>
+        public static JsonObject BrowserSearch() => new() { ["type"] = Types.BrowserSearch };
+
+        /// <summary>
+        /// A <c>code_interpreter</c> tool entry for the <c>tools</c> array (gpt-oss models). Compound
+        /// systems run code automatically and do not need this entry.
+        /// </summary>
+        public static JsonObject CodeInterpreter() => new() { ["type"] = Types.CodeInterpreter };
+
+        /// <summary>
+        /// Bundles built-in tool entries into a fresh <c>tools</c> <see cref="JsonArray"/> (deep-cloning
+        /// each so entries built once can be reused without JSON-node re-parenting errors).
+        /// </summary>
+        public static JsonArray ToolsArray(params JsonObject[] tools)
+        {
+            var array = new JsonArray();
+            if (tools is not null)
+                foreach (var tool in tools)
+                    if (tool is not null)
+                        array.Add(tool.DeepClone());
+            return array;
+        }
+
+        /// <summary>The <c>type</c> values for gpt-oss built-in tool entries.</summary>
+        public static class Types
+        {
+            public const string BrowserSearch = "browser_search";
+            public const string CodeInterpreter = "code_interpreter";
+        }
+
+        /// <summary>
+        /// <c>enabled_tools</c> names for Compound systems. Note: <c>browser_automation</c> (Anchor) is
+        /// deprecated and intentionally omitted.
+        /// </summary>
+        public static class Compound
+        {
+            public const string WebSearch = "web_search";
+            public const string CodeInterpreter = "code_interpreter";
+            public const string VisitWebsite = "visit_website";
+            public const string WolframAlpha = "wolfram_alpha";
+        }
+    }
+
+    /// <summary>
+    /// Convenience extensions for issuing chat completions with built-in server-side tools. Implemented
+    /// as extensions over <see cref="IGroqApiClient.CreateChatCompletionAsync(JsonObject)"/> so they add
+    /// no members to the interface (existing implementers/mocks are unaffected).
+    /// </summary>
+    public static class GroqBuiltInToolsExtensions
+    {
+        /// <summary>
+        /// Sends a chat completion with the given built-in tool entries in the <c>tools</c> array.
+        /// Typically used with gpt-oss models and <see cref="GroqBuiltInTools.BrowserSearch"/> /
+        /// <see cref="GroqBuiltInTools.CodeInterpreter"/>. Set <c>tool_choice</c> (e.g. "required") via
+        /// <paramref name="options"/>. Read what ran with <see cref="GroqExecutedTool.FromResponse"/>.
+        /// </summary>
+        public static Task<JsonObject?> CreateChatCompletionWithBuiltInToolsAsync(
+            this IGroqApiClient client,
+            JsonArray messages,
+            string model,
+            IEnumerable<JsonObject> builtInTools,
+            GroqChatOptions? options = null)
+        {
+            if (client is null) throw new ArgumentNullException(nameof(client));
+            if (messages is null) throw new ArgumentNullException(nameof(messages));
+            if (builtInTools is null) throw new ArgumentNullException(nameof(builtInTools));
+
+            var tools = new JsonArray();
+            foreach (var tool in builtInTools)
+                if (tool is not null)
+                    tools.Add(tool.DeepClone());
+
+            var request = new JsonObject
+            {
+                ["model"] = model,
+                ["messages"] = messages.DeepClone().AsArray(),
+                ["tools"] = tools
+            };
+            options?.ApplyTo(request);
+            return client.CreateChatCompletionAsync(request);
+        }
+    }
+}

--- a/GroqExecutedTool.cs
+++ b/GroqExecutedTool.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// A single entry from a response's <c>executed_tools</c> array — one server-side tool the model ran
+    /// (web search, code interpreter, etc.). Works for both Compound systems and gpt-oss built-in tools,
+    /// which share the same <c>choices[0].message.executed_tools</c> location.
+    /// <para>
+    /// Field names vary slightly by tool/model (e.g. code execution reports <c>type: "python"</c> with
+    /// <c>output</c>, others use <c>name</c>/<c>code_results</c>), so accessors are best-effort and
+    /// <see cref="Raw"/> exposes the original JSON for anything not surfaced here.
+    /// </para>
+    /// </summary>
+    public sealed record GroqExecutedTool
+    {
+        /// <summary>Position of this tool in the executed_tools array, when present.</summary>
+        public int? Index { get; init; }
+
+        /// <summary>The tool <c>type</c> (e.g. "python", "browser_search"), when present.</summary>
+        public string? Type { get; init; }
+
+        /// <summary>The tool <c>name</c>, when present.</summary>
+        public string? Name { get; init; }
+
+        /// <summary>The tool <c>arguments</c> (often a JSON string, e.g. the generated code), when present.</summary>
+        public string? Arguments { get; init; }
+
+        /// <summary>The tool <c>output</c> / <c>code_results</c>, when present.</summary>
+        public string? Output { get; init; }
+
+        /// <summary>The original JSON object for this entry — escape hatch for tool-specific fields.</summary>
+        public JsonObject Raw { get; init; } = new();
+
+        /// <summary>Projects a single <c>executed_tools</c> element into a <see cref="GroqExecutedTool"/>.</summary>
+        public static GroqExecutedTool From(JsonObject entry) => new()
+        {
+            Index = AsInt(entry["index"]),
+            Type = AsString(entry["type"]),
+            Name = AsString(entry["name"]),
+            Arguments = AsString(entry["arguments"]),
+            Output = AsString(entry["output"]) ?? AsString(entry["code_results"]),
+            Raw = entry,
+        };
+
+        /// <summary>
+        /// Reads and projects the <c>executed_tools</c> array from a chat/compound response. Returns an
+        /// empty list when none is present.
+        /// </summary>
+        public static IReadOnlyList<GroqExecutedTool> FromResponse(JsonObject? response)
+        {
+            if (response?["choices"]?[0]?["message"]?["executed_tools"] is not JsonArray array)
+                return Array.Empty<GroqExecutedTool>();
+
+            var list = new List<GroqExecutedTool>(array.Count);
+            foreach (var node in array)
+                if (node is JsonObject entry)
+                    list.Add(From(entry));
+            return list;
+        }
+
+        // Tolerant readers: GetValue<T>() throws on a type mismatch, so fall back to a JSON rendering.
+        private static string? AsString(JsonNode? node) => node switch
+        {
+            null => null,
+            JsonValue value => value.TryGetValue<string>(out var s) ? s : value.ToString(),
+            _ => node.ToJsonString(),
+        };
+
+        private static int? AsInt(JsonNode? node) =>
+            node is JsonValue value && value.TryGetValue<int>(out var i) ? i : null;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -522,6 +522,35 @@ var response = await groqApi.CreateCompoundCompletionAsync(
 var executed = GroqApiClient.GetExecutedTools(response); // which built-in tools the system ran
 ```
 
+## 🧰 Built-in server-side tools (v2.3)
+
+Typed builders and identifiers so you can attach Groq's built-in, server-executed tools without hand-writing JSON.
+
+**gpt-oss models** take built-in tools in the `tools` array:
+
+```csharp
+var response = await groqApi.CreateChatCompletionWithBuiltInToolsAsync(
+    messages,
+    GroqModels.GptOss120B,
+    new[] { GroqBuiltInTools.BrowserSearch() },          // and/or GroqBuiltInTools.CodeInterpreter()
+    new GroqChatOptions { ToolChoice = "required" });    // optional
+```
+
+**Compound systems** enable tools by name — pass the typed constants instead of magic strings:
+
+```csharp
+var response = await groqApi.CreateCompoundCompletionAsync(
+    messages,
+    enabledTools: new[] { GroqBuiltInTools.Compound.WebSearch, GroqBuiltInTools.Compound.VisitWebsite });
+```
+
+Read what actually ran — typed, works for both compound and gpt-oss:
+
+```csharp
+foreach (var tool in GroqExecutedTool.FromResponse(response))
+    Console.WriteLine($"{tool.Type ?? tool.Name}: {tool.Output}");   // .Raw for tool-specific fields
+```
+
 ## 🌱 Optional Prompt Compression (v2.1)
 
 A "greening"/cost feature: reduce a prompt's token footprint before sending. This is **opt-in lossy
@@ -687,6 +716,7 @@ v2.0 is backwards compatible. Existing code will continue to work. New features 
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
 
 ### v2.3 (unreleased)
+- **Built-in server-side tools helpers** — `GroqBuiltInTools` builders (`BrowserSearch()`, `CodeInterpreter()`) and identifier constants (`GroqBuiltInTools.Compound.*`) for adding Groq's server-side tools without raw JSON, a `CreateChatCompletionWithBuiltInToolsAsync` convenience extension, and a typed `GroqExecutedTool.FromResponse` for inspecting `executed_tools` on both Compound and gpt-oss runs.
 - **Typed API errors** — non-2xx responses now throw `GroqApiException` (and status-specific subtypes: `GroqRateLimitException`, `GroqAuthenticationException`, `GroqPermissionException`, `GroqBadRequestException`, `GroqNotFoundException`, `GroqServerException`) exposing `StatusCode`, parsed `ErrorCode`/`ErrorType`, and `ResponseBody`. All derive from `HttpRequestException`, so existing catch blocks are unaffected. Streaming errors now include the response body too.
 
 ### v2.2 (2026-07)


### PR DESCRIPTION
Closes #26.

## Summary
Typed builders and identifiers for Groq's built-in, server-executed tools so callers don't hand-write raw JSON, plus a typed reader for `executed_tools`.

## Changes
- **`GroqBuiltInTools`** (new)
  - Builders for the gpt-oss `tools` array: `BrowserSearch()` → `{"type":"browser_search"}`, `CodeInterpreter()` → `{"type":"code_interpreter"}`, plus `ToolsArray(...)`.
  - `GroqBuiltInTools.Types` constants for those `type` values.
  - `GroqBuiltInTools.Compound` constants for `compound_custom.tools.enabled_tools`: `WebSearch`, `CodeInterpreter`, `VisitWebsite`, `WolframAlpha`. Deprecated `browser_automation` (Anchor) intentionally omitted per the issue.
- **`CreateChatCompletionWithBuiltInToolsAsync`** — convenience extension on `IGroqApiClient` (an *extension*, not an interface member, so existing implementers/mocks are unaffected). Wraps built-in tool entries into a request and sends it.
- **`GroqExecutedTool`** (new) + `FromResponse` — typed projection of `choices[0].message.executed_tools`, the same location for both Compound and gpt-oss runs. Tolerant of field variance (`type`/`name`, `output`/`code_results`); `.Raw` exposes the original JSON. The existing raw `GroqApiClient.GetExecutedTools` is unchanged, with its doc updated to note gpt-oss coverage.

## Non-breaking
Purely additive — no existing signature changed, and `IGroqApiClient` gains no members (the convenience method is an extension). Existing `enabledTools: new[] { "web_search" }` string usage still works; the new constants are equivalent values.

## Verification
Request/response shapes verified against `console.groq.com/docs` (browser-search, code-execution) on 2026-07-13, then **live-smoke-tested** against the API:
- gpt-oss `openai/gpt-oss-20b` + `BrowserSearch()` via the new extension → **16** `executed_tools`, first `type=browser_search`, `name=browser.search`, read via `GroqExecutedTool.FromResponse`.
- `groq/compound-mini` + `Compound.WebSearch` → typed executed tool (`type=search`, `index=0`); raw and typed counts agreed.
- Builder JSON shapes asserted exact.

Build clean (0 warnings / 0 errors).

> Note: `groq/compound` (full) returned `413 request_too_large` on the test key — a per-account TPM limit on that larger model, not a code issue (the identical code path on `compound-mini` succeeded). Surfaced cleanly as the new `GroqApiException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)