### PR TITLE
Add Responses API support (beta) (closes #24)

### DIFF
--- a/GroqApiClient.cs
+++ b/GroqApiClient.cs
@@ -21,6 +21,7 @@ namespace GroqApiLibrary
         private const string SpeechEndpoint = "/audio/speech";
         private const string FilesEndpoint = "/files";
         private const string BatchesEndpoint = "/batches";
+        private const string ResponsesEndpoint = "/responses";
 
         // Vision-capable models. Verified against console.groq.com/docs/models &amp; /deprecations (2026-07-12).
         // qwen/qwen3.6-27b is the current recommended vision model. The Llama 4 / Llama 3.2 vision
@@ -358,6 +359,73 @@ namespace GroqApiLibrary
         /// </summary>
         public static JsonArray? GetExecutedTools(JsonObject? response)
             => response?["choices"]?[0]?["message"]?["executed_tools"] as JsonArray;
+
+        #endregion
+
+        #region Responses API (beta)
+
+        /// <summary>
+        /// <b>Beta.</b> Creates a response via the OpenAI-compatible Responses API
+        /// (<c>POST /openai/v1/responses</c>) and returns the raw response object.
+        /// <para>
+        /// Read the answer with <see cref="GetResponseOutputText"/> and usage with
+        /// <see cref="GroqUsage.FromResponse"/>. Groq does <b>not</b> support stateful conversations
+        /// (<c>previous_response_id</c>/<c>store</c>): keep the history yourself and pass it in
+        /// <paramref name="input"/> each call.
+        /// </para>
+        /// This surface is beta and may change with the upstream API.
+        /// Verified against console.groq.com/docs/responses-api (2026-07-13).
+        /// </summary>
+        /// <param name="model">Model id (e.g. <c>openai/gpt-oss-120b</c>, <c>llama-3.3-70b-versatile</c>).</param>
+        /// <param name="input">A plain text string, or a message array (role/content objects).</param>
+        /// <param name="options">Optional request parameters (see <see cref="GroqResponseOptions"/>).</param>
+        public async Task<JsonObject?> CreateResponseAsync(string model, JsonNode input, GroqResponseOptions? options = null)
+        {
+            if (string.IsNullOrEmpty(model)) throw new ArgumentException("A model is required.", nameof(model));
+            if (input is null) throw new ArgumentNullException(nameof(input));
+
+            var request = new JsonObject
+            {
+                ["model"] = model,
+                ["input"] = input.DeepClone()
+            };
+            options?.ApplyTo(request);
+
+            var response = await _httpClient.PostAsJsonAsync(BaseUrl + ResponsesEndpoint, request);
+            await EnsureGroqSuccessAsync(response, "Responses API request");
+            return await response.Content.ReadFromJsonAsync<JsonObject>();
+        }
+
+        /// <summary>
+        /// <b>Beta.</b> Extracts the assistant text from a Responses API result: the top-level
+        /// <c>output_text</c> when present, otherwise the concatenation of <c>output[].content[].text</c>
+        /// entries of type <c>output_text</c>. Returns null when no text is found.
+        /// </summary>
+        public static string? GetResponseOutputText(JsonObject? response)
+        {
+            if (response is null) return null;
+
+            if (response["output_text"] is JsonValue direct && direct.TryGetValue<string>(out var text))
+                return text;
+
+            if (response["output"] is not JsonArray output) return null;
+
+            var builder = new StringBuilder();
+            foreach (var item in output)
+            {
+                if (item is not JsonObject message || message["content"] is not JsonArray content) continue;
+                foreach (var part in content)
+                {
+                    if (part is JsonObject partObj
+                        && partObj["type"]?.GetValue<string>() == "output_text"
+                        && partObj["text"] is JsonValue t
+                        && t.TryGetValue<string>(out var s))
+                        builder.Append(s);
+                }
+            }
+
+            return builder.Length > 0 ? builder.ToString() : null;
+        }
 
         #endregion
 

--- a/GroqResponseOptions.cs
+++ b/GroqResponseOptions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace GroqApiLibrary
+{
+    /// <summary>
+    /// <b>Beta.</b> Strongly-typed optional parameters for the Responses API
+    /// (<see cref="GroqApiClient.CreateResponseAsync"/>). Only the properties you set are sent.
+    /// <para>
+    /// Groq does not support stateful conversations, so there is no <c>previous_response_id</c>/<c>store</c>
+    /// here. Fields verified against console.groq.com/docs/responses-api (2026-07-13); this surface is beta
+    /// and may change with the upstream API.
+    /// </para>
+    /// </summary>
+    public class GroqResponseOptions
+    {
+        /// <summary>System-level guidance for the model (<c>instructions</c>).</summary>
+        public string? Instructions { get; set; }
+
+        /// <summary>Tool definitions (<c>tools</c>) — e.g. <c>code_interpreter</c>, <c>browser_search</c>, MCP.</summary>
+        public JsonArray? Tools { get; set; }
+
+        /// <summary>Tool selection strategy (<c>tool_choice</c>), e.g. "auto" or "required".</summary>
+        public JsonNode? ToolChoice { get; set; }
+
+        /// <summary>Reasoning effort ("low"/"medium"/"high"), sent as <c>reasoning.effort</c>.</summary>
+        public string? ReasoningEffort { get; set; }
+
+        /// <summary>Output formatting (<c>text</c>), e.g. a <c>format</c> object for JSON-schema output.</summary>
+        public JsonObject? Text { get; set; }
+
+        /// <summary>Sampling temperature.</summary>
+        public double? Temperature { get; set; }
+
+        /// <summary>Nucleus sampling probability mass (<c>top_p</c>).</summary>
+        public double? TopP { get; set; }
+
+        /// <summary>Maximum tokens to generate (<c>max_output_tokens</c>).</summary>
+        public int? MaxOutputTokens { get; set; }
+
+        /// <summary>Custom metadata (<c>metadata</c>) echoed back on the response.</summary>
+        public JsonObject? Metadata { get; set; }
+
+        /// <summary>Merges the set options into <paramref name="request"/> and returns it.</summary>
+        public JsonObject ApplyTo(JsonObject request)
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+
+            if (!string.IsNullOrEmpty(Instructions)) request["instructions"] = Instructions;
+            if (Tools is not null) request["tools"] = Tools.DeepClone();
+            if (ToolChoice is not null) request["tool_choice"] = ToolChoice.DeepClone();
+            if (!string.IsNullOrEmpty(ReasoningEffort))
+                request["reasoning"] = new JsonObject { ["effort"] = ReasoningEffort };
+            if (Text is not null) request["text"] = Text.DeepClone();
+            if (Temperature.HasValue) request["temperature"] = Temperature.Value;
+            if (TopP.HasValue) request["top_p"] = TopP.Value;
+            if (MaxOutputTokens.HasValue) request["max_output_tokens"] = MaxOutputTokens.Value;
+            if (Metadata is not null) request["metadata"] = Metadata.DeepClone();
+
+            return request;
+        }
+    }
+}

--- a/GroqUsage.cs
+++ b/GroqUsage.cs
@@ -53,8 +53,10 @@ namespace GroqApiLibrary
 
             var result = new GroqUsage
             {
-                PromptTokens = GetInt(usage, "prompt_tokens"),
-                CompletionTokens = GetInt(usage, "completion_tokens"),
+                // Chat completions use prompt_tokens/completion_tokens; the Responses API uses
+                // input_tokens/output_tokens. Fall back so this parser works for both.
+                PromptTokens = usage.ContainsKey("prompt_tokens") ? GetInt(usage, "prompt_tokens") : GetInt(usage, "input_tokens"),
+                CompletionTokens = usage.ContainsKey("completion_tokens") ? GetInt(usage, "completion_tokens") : GetInt(usage, "output_tokens"),
                 TotalTokens = GetInt(usage, "total_tokens"),
                 QueueTime = GetDouble(usage, "queue_time"),
                 PromptTime = GetDouble(usage, "prompt_time"),
@@ -65,6 +67,8 @@ namespace GroqApiLibrary
 
             if (usage["prompt_tokens_details"] is JsonObject details)
                 result.CachedTokens = GetInt(details, "cached_tokens");
+            else if (usage["input_tokens_details"] is JsonObject responsesDetails)
+                result.CachedTokens = GetInt(responsesDetails, "cached_tokens");
 
             return result;
         }

--- a/IGroqApiClient.cs
+++ b/IGroqApiClient.cs
@@ -76,6 +76,18 @@ namespace GroqApiLibrary
 
         #endregion
 
+        #region Responses API (beta)
+
+        /// <summary>
+        /// <b>Beta.</b> Creates a response via the OpenAI-compatible Responses API and returns the raw
+        /// response. Read the text with <see cref="GroqApiClient.GetResponseOutputText"/> and usage with
+        /// <see cref="GroqUsage.FromResponse"/>. Groq does not support stateful conversations, so pass the
+        /// full history in <paramref name="input"/> each call. Beta surface — may change with the API.
+        /// </summary>
+        Task<JsonObject?> CreateResponseAsync(string model, JsonNode input, GroqResponseOptions? options = null);
+
+        #endregion
+
         #region Audio
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -551,6 +551,25 @@ foreach (var tool in GroqExecutedTool.FromResponse(response))
     Console.WriteLine($"{tool.Type ?? tool.Name}: {tool.Output}");   // .Raw for tool-specific fields
 ```
 
+## 🧪 Responses API (beta, v2.3)
+
+OpenAI-compatible Responses API (`POST /openai/v1/responses`). **Beta** surface — may change with the upstream API.
+
+```csharp
+// Plain string input
+var resp = await groqApi.CreateResponseAsync(
+    GroqModels.GptOss120B,
+    "Explain quicksort in one sentence.",
+    new GroqResponseOptions { ReasoningEffort = "low", MaxOutputTokens = 200 });
+
+string? answer = GroqApiClient.GetResponseOutputText(resp);   // top-level output_text (falls back to output[])
+GroqUsage usage = GroqUsage.FromResponse(resp)!;              // maps input_tokens/output_tokens too
+```
+
+You can also pass a message array as `input`, and set `Instructions`, `Tools`, `ToolChoice`, `Text` (JSON-schema output), `Temperature`, `Top_p`, and `Metadata` via `GroqResponseOptions`.
+
+> **Stateful conversations are not supported on Groq** (`previous_response_id`/`store` are unavailable) — keep the history yourself and pass it in `input` on every call.
+
 ## 🌱 Optional Prompt Compression (v2.1)
 
 A "greening"/cost feature: reduce a prompt's token footprint before sending. This is **opt-in lossy
@@ -716,6 +735,7 @@ v2.0 is backwards compatible. Existing code will continue to work. New features 
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
 
 ### v2.3 (unreleased)
+- **Responses API (beta)** — `CreateResponseAsync(model, input, GroqResponseOptions?)` for the OpenAI-compatible `POST /openai/v1/responses`, with `GetResponseOutputText` to read the answer and typed `GroqResponseOptions`. `GroqUsage.FromResponse` now also maps the Responses `input_tokens`/`output_tokens` shape. Stateful conversations aren't supported on Groq — pass full history each call.
 - **Built-in server-side tools helpers** — `GroqBuiltInTools` builders (`BrowserSearch()`, `CodeInterpreter()`) and identifier constants (`GroqBuiltInTools.Compound.*`) for adding Groq's server-side tools without raw JSON, a `CreateChatCompletionWithBuiltInToolsAsync` convenience extension, and a typed `GroqExecutedTool.FromResponse` for inspecting `executed_tools` on both Compound and gpt-oss runs.
 - **Typed API errors** — non-2xx responses now throw `GroqApiException` (and status-specific subtypes: `GroqRateLimitException`, `GroqAuthenticationException`, `GroqPermissionException`, `GroqBadRequestException`, `GroqNotFoundException`, `GroqServerException`) exposing `StatusCode`, parsed `ErrorCode`/`ErrorType`, and `ResponseBody`. All derive from `HttpRequestException`, so existing catch blocks are unaffected. Streaming errors now include the response body too.
 


### PR DESCRIPTION
Closes #24.

## Summary
OpenAI-compatible **Responses API** (`POST /openai/v1/responses`), shipped **beta** since the upstream surface may still churn.

## Changes
- **`CreateResponseAsync(string model, JsonNode input, GroqResponseOptions? options = null)`** on `IGroqApiClient`/`GroqApiClient` — returns the raw response object. `input` is a `JsonNode` (plain string *or* a message array); it's deep-cloned before sending.
- **`GroqResponseOptions`** — typed `Instructions`, `Tools`, `ToolChoice`, `ReasoningEffort` (→ `reasoning.effort`), `Text` (JSON-schema output), `Temperature`, `TopP`, `MaxOutputTokens`, `Metadata`, applied via `ApplyTo` (same idiom as `GroqChatOptions`).
- **`GetResponseOutputText`** — reads top-level `output_text`, falling back to concatenating `output[].content[]` entries of type `output_text`.
- **`GroqUsage.FromResponse`** now also maps the Responses usage shape (`input_tokens`/`output_tokens`, `input_tokens_details.cached_tokens`) so it works for both APIs instead of returning zeros. The issue proposed reusing `FromResponse`; verifying the actual payload showed the field names differ, so this makes the reuse real.
- Errors route through the `#35` `EnsureGroqSuccessAsync` helper (typed `GroqApiException`).

## Beta & statefulness
Type/methods are documented **Beta** (may change with the API). Groq does **not** support stateful conversations — `previous_response_id`/`store` are unsupported, so callers pass full history in `input` each call (documented in XML docs + README).

## Non-breaking
Additive. `GroqUsage.FromResponse`'s fallback only triggers when the chat token keys are absent, so existing chat parsing is byte-for-byte identical. `CreateResponseAsync` is added to `IGroqApiClient`, consistent with how Files/Batch endpoints were added in v2.2.

## Verification
Shapes verified against `console.groq.com/docs/responses-api` (2026-07-13), then **live-smoke-tested**:
- Plain string input → `status=completed`, `output_text="PONG"`.
- Message-array input + `Instructions`/`ReasoningEffort` → `"68"`.
- `GroqUsage.FromResponse` → **prompt=79, completion=46, total=125** (exercises the `input_tokens`/`output_tokens` fallback — non-zero proves the mapping).
- `ApplyTo` maps `reasoning.effort` and `max_output_tokens`.

8/8 assertions passed. Build clean (0 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)