### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -14,9 +14,9 @@
 		<PackageIcon>g_icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Groq, API, Windows, .NET, Core, AI, LLM, TTS, Whisper, Vision, Tool-Calling, Structured-Outputs</PackageTags>
-		<AssemblyVersion>2.2.0.0</AssemblyVersion>
-		<FileVersion>2.2.0.0</FileVersion>
-		<Version>2.2.0</Version>
+		<AssemblyVersion>2.3.0.0</AssemblyVersion>
+		<FileVersion>2.3.0.0</FileVersion>
+		<Version>2.3.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ v2.0 is backwards compatible. Existing code will continue to work. New features 
 - `max_tokens` deprecated in favor of `max_completion_tokens`
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
 
-### v2.3 (unreleased)
+### v2.3.0 (2026-07)
 - **Responses API (beta)** — `CreateResponseAsync(model, input, GroqResponseOptions?)` for the OpenAI-compatible `POST /openai/v1/responses`, with `GetResponseOutputText` to read the answer and typed `GroqResponseOptions`. `GroqUsage.FromResponse` now also maps the Responses `input_tokens`/`output_tokens` shape. Stateful conversations aren't supported on Groq — pass full history each call.
 - **Built-in server-side tools helpers** — `GroqBuiltInTools` builders (`BrowserSearch()`, `CodeInterpreter()`) and identifier constants (`GroqBuiltInTools.Compound.*`) for adding Groq's server-side tools without raw JSON, a `CreateChatCompletionWithBuiltInToolsAsync` convenience extension, and a typed `GroqExecutedTool.FromResponse` for inspecting `executed_tools` on both Compound and gpt-oss runs.
 - **Typed API errors** — non-2xx responses now throw `GroqApiException` (and status-specific subtypes: `GroqRateLimitException`, `GroqAuthenticationException`, `GroqPermissionException`, `GroqBadRequestException`, `GroqNotFoundException`, `GroqServerException`) exposing `StatusCode`, parsed `ErrorCode`/`ErrorType`, and `ResponseBody`. All derive from `HttpRequestException`, so existing catch blocks are unaffected. Streaming errors now include the response body too.


### PR DESCRIPTION
Bumps `AssemblyVersion`/`FileVersion`/`Version` to **2.3.0** and marks the v2.3.0 changelog section released (was "unreleased").

Ships the v2.3 work merged this cycle:
- Typed API errors — `GroqApiException` hierarchy (#35)
- Built-in server-side tools helpers — `GroqBuiltInTools` / `GroqExecutedTool` (#36, closes #26)
- Responses API (beta) — `CreateResponseAsync` / `GroqResponseOptions` (#37, closes #24)
- DI-extension consolidation (#34)

Build clean (0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)