### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/GroqApiLibrary.csproj
+++ b/GroqApiLibrary.csproj
@@ -14,9 +14,9 @@
 		<PackageIcon>g_icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Groq, API, Windows, .NET, Core, AI, LLM, TTS, Whisper, Vision, Tool-Calling, Structured-Outputs</PackageTags>
-		<AssemblyVersion>2.3.0.0</AssemblyVersion>
-		<FileVersion>2.3.0.0</FileVersion>
-		<Version>2.3.0</Version>
+		<AssemblyVersion>2.4.0.0</AssemblyVersion>
+		<FileVersion>2.4.0.0</FileVersion>
+		<Version>2.4.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ v2.0 is backwards compatible. Existing code will continue to work. New features 
 - `max_tokens` deprecated in favor of `max_completion_tokens`
 - Added `GroqModels`, `OrpheusVoices`, `ServiceTiers`, `ReasoningEffort`, `ReasoningFormat` static classes for convenience
 
-### Unreleased
+### v2.4.0 (2026-07)
 - **Remote MCP tools (beta)** — `GroqBuiltInTools.Mcp(...)` builds a remote MCP server tool entry (`type: "mcp"`, with `server_label`/`server_url`/`headers`/`server_description`/`require_approval`/`allowed_tools`) usable in both Chat Completions and the Responses API, plus `GroqBuiltInTools.Approval` constants. `server_url` must be reachable from Groq's cloud over public HTTPS.
 
 ### v2.3.0 (2026-07)


### PR DESCRIPTION
Bumps `AssemblyVersion`/`FileVersion`/`Version` to **2.4.0** and marks the v2.4.0 changelog section released.

Ships the remote MCP tool builder (beta) — `GroqBuiltInTools.Mcp(...)` (#39, closes #25). New additive public API → minor bump.

Build clean (0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)